### PR TITLE
Non-incremental attack tables

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -4,17 +4,14 @@ on:
   workflow_call:
 
 jobs:
-  compilation:
+  linux-compilation:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
         compiler:
           - g++
           - clang++
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -32,6 +29,35 @@ jobs:
 
       - name: Build Release
         run: make CXX=${{ matrix.compiler }}
+
+      - name: Test
+        run: make CXX=${{ matrix.compiler }} test
+
+  macos-compilation:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - g++
+          - clang++
+    runs-on: macos-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check Compiler
+        run: ${{ matrix.compiler }} -v
+
+      - name: Build Debug
+        run: make debug CXX=${{ matrix.compiler }} ARCH=x86-64-v2
+
+      - name: Clean build
+        run: make clean
+
+      - name: Build Release
+        run: make CXX=${{ matrix.compiler }} ARCH=x86-64-v2
 
   windows-compilation:
     strategy:
@@ -70,3 +96,6 @@ jobs:
 
       - name: Build Release
         run: make CXX=${{ matrix.compiler }}
+
+      - name: Test
+        run: make CXX=${{ matrix.compiler }} test

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -51,13 +51,13 @@ jobs:
         run: ${{ matrix.compiler }} -v
 
       - name: Build Debug
-        run: make debug CXX=${{ matrix.compiler }} ARCH=x86-64-v2
+        run: make debug CXX=${{ matrix.compiler }} ARCH=x86-64-v3
 
       - name: Clean build
         run: make clean
 
       - name: Build Release
-        run: make CXX=${{ matrix.compiler }} ARCH=x86-64-v2
+        run: make CXX=${{ matrix.compiler }} ARCH=x86-64-v3
 
   windows-compilation:
     strategy:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - x86-64
-          - x86-64-v2
           - x86-64-v3
           - x86-64-v4
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,7 @@
 clockwork
 
 # Cmake folders
-build-release/
-build-debug/
+build*/
 
 # IDEs
 .idea/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,18 @@ project(
         LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_OSX_ARCHITECTURES "x86_64")
 include_directories(src)
 
-enable_testing()
-set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
-function(do_test name)
-  add_executable(${name} tests/${name}.cpp ${srcs})
-  add_test(${name} ${name})
-endfunction()
+#Optimizations
+set(CLOCKWORK_MARCH_TARGET "native" CACHE STRING "Specify the target architecture for -march (e.g., native, skylake, znver2). Set to OFF or empty to disable.")
+
+if(CLOCKWORK_MARCH_TARGET AND NOT CLOCKWORK_MARCH_TARGET STREQUAL "OFF")
+    message(STATUS "Using -march=${CLOCKWORK_MARCH_TARGET} for optimizations")
+    add_compile_options("-march=${CLOCKWORK_MARCH_TARGET}")
+else()
+    message(STATUS "-march flag disabled by user")
+endif()
 
 # Sorted list of source files
 set(srcs
@@ -46,6 +50,14 @@ set_target_properties(clockwork PROPERTIES
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO)
 
+# Tests
+enable_testing()
+set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
+function(do_test name)
+  add_executable(${name} tests/${name}.cpp ${srcs})
+  add_test(${name} ${name})
+endfunction()
+
 do_test(test_perft)
 do_test(test_position)
 
@@ -63,16 +75,6 @@ target_link_options(clockwork PRIVATE
         $<$<CONFIG:Debug>:
         -fsanitize=address,undefined
         >)
-
-#Optimizations
-set(CLOCKWORK_MARCH_TARGET "native" CACHE STRING "Specify the target architecture for -march (e.g., native, skylake, znver2). Set to OFF or empty to disable.")
-
-if(CLOCKWORK_MARCH_TARGET AND NOT CLOCKWORK_MARCH_TARGET STREQUAL "OFF")
-    message(STATUS "Using -march=${CLOCKWORK_MARCH_TARGET} for optimizations")
-    target_compile_options(clockwork PRIVATE "-march=${CLOCKWORK_MARCH_TARGET}")
-else()
-    message(STATUS "-march flag disabled by user")
-endif()
 
 # LTO
 include(CheckIPOSupported)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(srcs
     src/square.hpp
     src/uci.cpp
     src/uci.hpp
+    src/util/bit.hpp
     src/util/static_vector.hpp
     src/util/types.hpp
     src/util/vec.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,48 @@ project(
         DESCRIPTION "HCE Community Engine"
         LANGUAGES CXX)
 
-add_executable(clockwork src/main.cpp src/uci.cpp src/uci.hpp src/square.hpp src/move.hpp src/common.hpp src/util/types.hpp)
+set(CMAKE_CXX_STANDARD 20)
+include_directories(src)
 
+enable_testing()
+set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE)
+function(do_test name)
+  add_executable(${name} tests/${name}.cpp ${srcs})
+  add_test(${name} ${name})
+endfunction()
+
+# Sorted list of source files
+set(srcs
+    src/board.cpp
+    src/board.hpp
+    src/common.hpp
+    src/geometry.hpp
+    src/move.cpp
+    src/move.hpp
+    src/movegen.cpp
+    src/movegen.hpp
+    src/perft.cpp
+    src/perft.hpp
+    src/position.cpp
+    src/position.hpp
+    src/square.hpp
+    src/uci.cpp
+    src/uci.hpp
+    src/util/static_vector.hpp
+    src/util/types.hpp
+    src/util/vec.hpp
+    src/util/vec/avx2.hpp
+    src/util/vec/avx512.hpp
+)
+
+add_executable(clockwork ${srcs} src/main.cpp)
 set_target_properties(clockwork PROPERTIES
         CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO)
+
+do_test(test_perft)
+do_test(test_position)
 
 # Warnings
 # We don't support MSVC

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CMAKE_FLAGS := -DCMAKE_CXX_COMPILER=$(CXX) -DCLOCKWORK_MARCH_TARGET=$(ARCH)
 
 EXE := "$(EXE)$(SUFFIX)"
 
-.PHONY: all release debug clean
+.PHONY: all release debug test clean
 
 all: release
 
@@ -41,6 +41,9 @@ release:
 debug:
 	cmake -DCMAKE_BUILD_TYPE=Debug $(CMAKE_FLAGS) -B build-debug -S . && cmake --build build-debug -j
 	$(COPY) $(call MK_PATH,"build-debug/clockwork$(SUFFIX)") $(EXE)
+
+test: release
+	ctest --test-dir build-release
 
 clean:
 	-$(RM_DIR) build-debug build-release

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1,0 +1,30 @@
+#include "board.hpp"
+
+#include <iomanip>
+#include <iostream>
+
+#include "square.hpp"
+
+namespace Clockwork {
+
+std::ostream& operator<<(std::ostream& os, const Wordboard& at) {
+    std::ios state{nullptr};
+    state.copyfmt(os);
+
+    for (int rank = 7; rank >= 0; rank--)
+    {
+        for (int file = 0; file < 8; file++)
+        {
+            const Square sq    = Square::fromFileAndRank(file, rank);
+            const u16    value = at[sq];
+
+            os << std::hex << std::setfill('0') << std::setw(4) << value << ' ';
+        }
+        os << std::endl;
+    }
+
+    os.copyfmt(state);
+    return os;
+}
+
+}

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -11,12 +11,10 @@ std::ostream& operator<<(std::ostream& os, const Wordboard& at) {
     std::ios state{nullptr};
     state.copyfmt(os);
 
-    for (int rank = 7; rank >= 0; rank--)
-    {
-        for (int file = 0; file < 8; file++)
-        {
-            const Square sq    = Square::fromFileAndRank(file, rank);
-            const u16    value = at[sq];
+    for (int rank = 7; rank >= 0; rank--) {
+        for (int file = 0; file < 8; file++) {
+            Square sq    = Square::from_file_and_rank(file, rank);
+            u16    value = at[sq];
 
             os << std::hex << std::setfill('0') << std::setw(4) << value << ' ';
         }

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -19,7 +19,9 @@ struct PieceId {
         assert(raw < 0x10);
     }
 
-    constexpr u16 toPieceMask() const { return static_cast<u16>(1 << raw); }
+    [[nodiscard]] constexpr u16 to_piece_mask() const {
+        return static_cast<u16>(1 << raw);
+    }
 };
 
 static_assert(sizeof(PieceId) == sizeof(u8));
@@ -27,22 +29,33 @@ static_assert(sizeof(PieceId) == sizeof(u8));
 struct Place {
     u8 raw = 0;
 
-    static constexpr Place empty() { return {}; }
+    static constexpr Place empty() {
+        return {};
+    }
 
     constexpr Place() = default;
+
     constexpr Place(Color color, PieceType pt, PieceId id) {
         raw =
           static_cast<u8>((static_cast<int>(color) << 7) | (static_cast<int>(pt) << 4) | id.raw);
     }
 
-    constexpr bool      isEmpty() const { return raw == 0; }
-    constexpr Color     color() const { return static_cast<Color>((raw & 0x80) != 0); }
-    constexpr PieceType ptype() const { return static_cast<PieceType>((raw >> 4) & 0x7); }
-    constexpr PieceId   id() const { return PieceId{static_cast<u8>(raw & 0xF)}; }
+    [[nodiscard]] constexpr bool is_empty() const {
+        return raw == 0;
+    }
+    [[nodiscard]] constexpr Color color() const {
+        return static_cast<Color>((raw & 0x80) != 0);
+    }
+    [[nodiscard]] constexpr PieceType ptype() const {
+        return static_cast<PieceType>((raw >> 4) & 0x7);
+    }
+    [[nodiscard]] constexpr PieceId id() const {
+        return PieceId{static_cast<u8>(raw & 0xF)};
+    }
 
-    constexpr char toChar() const {
-        constexpr std::array<std::string_view, 2> str{{".PNBRQK", ".pnbrqk"}};
-        return str[static_cast<usize>(color())][static_cast<usize>(ptype())];
+    [[nodiscard]] constexpr char to_char() const {
+        constexpr std::array<std::string_view, 2> STR{{".PNBRQK", ".pnbrqk"}};
+        return STR[static_cast<usize>(color())][static_cast<usize>(ptype())];
     }
 
     bool operator==(const Place&) const = default;
@@ -53,22 +66,31 @@ static_assert(sizeof(Place) == sizeof(u8));
 struct Byteboard {
     std::array<Place, 64> mailbox;
 
-    v512 toVec() const { return std::bit_cast<v512>(mailbox); }
+    [[nodiscard]] v512 to_vec() const {
+        return std::bit_cast<v512>(mailbox);
+    }
 
-    u64 getEmptyBitboard() const { return toVec().zero8(); }
+    [[nodiscard]] u64 get_empty_bitboard() const {
+        return to_vec().zero8();
+    }
 
-    u64 getColorBitboard(Color color) const {
-        const auto vec = toVec();
+    [[nodiscard]] u64 get_color_bitboard(Color color) const {
+        auto vec = to_vec();
         return ~(vec.msb8() ^ static_cast<u64>(-static_cast<i64>(color))) & vec.nonzero8();
     }
 
-    u64 bitboardFor(Color color, PieceType ptype) const {
-        const Place p{color, ptype, PieceId{0}};
-        return v512::eq8(toVec() & v512::broadcast8(0xF0), v512::broadcast8(p.raw));
+    [[nodiscard]] u64 bitboard_for(Color color, PieceType ptype) const {
+        Place p{color, ptype, PieceId{0}};
+        return v512::eq8(to_vec() & v512::broadcast8(0xF0), v512::broadcast8(p.raw));
     }
 
-    constexpr Place& operator[](Square sq) { return mailbox[sq.raw]; }
-    constexpr Place  operator[](Square sq) const { return mailbox[sq.raw]; }
+    constexpr Place& operator[](Square sq) {
+        return mailbox[sq.raw];
+    }
+
+    constexpr Place operator[](Square sq) const {
+        return mailbox[sq.raw];
+    }
 
     bool operator==(const Byteboard& other) const = default;
 };
@@ -78,15 +100,22 @@ static_assert(sizeof(Byteboard) == 64);
 struct Wordboard {
     std::array<u16, 64> mailbox;
 
-    std::array<v512, 2> toVec() const { return std::bit_cast<std::array<v512, 2>>(mailbox); }
-
-    u64 getAttackedBitboard() const {
-        const auto vec = toVec();
-        return concat64(vec[0].nonzero16(), vec[1].nonzero16());
+    [[nodiscard]] std::array<v512, 2> to_vec() const {
+        return std::bit_cast<std::array<v512, 2>>(mailbox);
     }
 
-    constexpr u16& operator[](Square sq) { return mailbox[sq.raw]; }
-    constexpr u16  operator[](Square sq) const { return mailbox[sq.raw]; }
+    [[nodiscard]] u64 get_attacked_bitboard() const {
+        const auto VEC = to_vec();
+        return concat64(VEC[0].nonzero16(), VEC[1].nonzero16());
+    }
+
+    constexpr u16& operator[](Square sq) {
+        return mailbox[sq.raw];
+    }
+
+    constexpr u16 operator[](Square sq) const {
+        return mailbox[sq.raw];
+    }
 
     bool                 operator==(const Wordboard& other) const = default;
     friend std::ostream& operator<<(std::ostream& os, const Wordboard& at);

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <array>
+#include <bit>
+#include <iosfwd>
+
+#include "util/types.hpp"
+#include "util/vec.hpp"
+#include "common.hpp"
+#include "square.hpp"
+
+namespace Clockwork {
+
+struct PieceId {
+    u8 raw;
+
+    constexpr PieceId(u8 raw) :
+        raw(raw) {
+        assert(raw < 0x10);
+    }
+
+    constexpr u16 toPieceMask() const { return static_cast<u16>(1 << raw); }
+};
+
+static_assert(sizeof(PieceId) == sizeof(u8));
+
+struct Place {
+    u8 raw = 0;
+
+    static constexpr Place empty() { return {}; }
+
+    constexpr Place() = default;
+    constexpr Place(Color color, PieceType pt, PieceId id) {
+        raw =
+          static_cast<u8>((static_cast<int>(color) << 7) | (static_cast<int>(pt) << 4) | id.raw);
+    }
+
+    constexpr bool      isEmpty() const { return raw == 0; }
+    constexpr Color     color() const { return static_cast<Color>((raw & 0x80) != 0); }
+    constexpr PieceType ptype() const { return static_cast<PieceType>((raw >> 4) & 0x7); }
+    constexpr PieceId   id() const { return PieceId{static_cast<u8>(raw & 0xF)}; }
+
+    constexpr char toChar() const {
+        constexpr std::array<std::string_view, 2> str{{".PNBRQK", ".pnbrqk"}};
+        return str[static_cast<usize>(color())][static_cast<usize>(ptype())];
+    }
+
+    bool operator==(const Place&) const = default;
+};
+
+static_assert(sizeof(Place) == sizeof(u8));
+
+struct Byteboard {
+    std::array<Place, 64> mailbox;
+
+    v512 toVec() const { return std::bit_cast<v512>(mailbox); }
+
+    u64 getEmptyBitboard() const { return toVec().zero8(); }
+
+    u64 getColorBitboard(Color color) const {
+        const auto vec = toVec();
+        return ~(vec.msb8() ^ static_cast<u64>(-static_cast<i64>(color))) & vec.nonzero8();
+    }
+
+    u64 bitboardFor(Color color, PieceType ptype) const {
+        const Place p{color, ptype, PieceId{0}};
+        return v512::eq8(toVec() & v512::broadcast8(0xF0), v512::broadcast8(p.raw));
+    }
+
+    constexpr Place& operator[](Square sq) { return mailbox[sq.raw]; }
+    constexpr Place  operator[](Square sq) const { return mailbox[sq.raw]; }
+
+    bool operator==(const Byteboard& other) const = default;
+};
+
+static_assert(sizeof(Byteboard) == 64);
+
+struct Wordboard {
+    std::array<u16, 64> mailbox;
+
+    std::array<v512, 2> toVec() const { return std::bit_cast<std::array<v512, 2>>(mailbox); }
+
+    u64 getAttackedBitboard() const {
+        const auto vec = toVec();
+        return concat64(vec[0].nonzero16(), vec[1].nonzero16());
+    }
+
+    constexpr u16& operator[](Square sq) { return mailbox[sq.raw]; }
+    constexpr u16  operator[](Square sq) const { return mailbox[sq.raw]; }
+
+    bool                 operator==(const Wordboard& other) const = default;
+    friend std::ostream& operator<<(std::ostream& os, const Wordboard& at);
+};
+
+static_assert(sizeof(Wordboard) == 128);
+
+}

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,11 +1,27 @@
 #pragma once
 
+#include "util/types.hpp"
+
 namespace Clockwork {
 
 enum class Color {
     White,
     Black
 };
+
+constexpr char color_char(Color color) {
+    using enum Color;
+    switch (color) {
+    case White :
+        return 'w';
+    case Black :
+        return 'b';
+    }
+}
+
+constexpr Color invert(Color color) {
+    return static_cast<Color>(static_cast<int>(color) ^ 1);
+}
 
 enum class PieceType {
     Pawn,
@@ -20,6 +36,8 @@ enum class PieceType {
 constexpr char piece_char(PieceType piece) {
     using enum PieceType;
     switch (piece) {
+    case None :
+        return '.';
     case Pawn :
         return 'p';
     case Knight :
@@ -32,8 +50,6 @@ constexpr char piece_char(PieceType piece) {
         return 'q';
     case King :
         return 'k';
-    case Empty :
-        return '.';
     }
 }
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -23,14 +23,14 @@ constexpr Color invert(Color color) {
     return static_cast<Color>(static_cast<int>(color) ^ 1);
 }
 
-enum class PieceType {
+enum class PieceType : u8 {
+    None,
     Pawn,
     Knight,
     Bishop,
     Rook,
     Queen,
     King,
-    Empty,
 };
 
 constexpr char piece_char(PieceType piece) {

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <utility>
+#include <tuple>
+
+#include "square.hpp"
+#include "util/types.hpp"
+#include "util/vec.hpp"
+
+namespace Clockwork::geometry {
+
+namespace internal {
+// 00rrrfff → 0rrr0fff
+forceinline constexpr auto expandSq(Square sq) -> u8 { return sq.raw + (sq.raw & 0b111000); }
+
+// 0rrr0fff → 00rrrfff
+template<typename V>
+forceinline auto compressCoords(V list) -> std::tuple<V, typename V::Mask8> {
+    const typename V::Mask8 valid = V::testn8(list, V::broadcast8(0x88));
+    const V compressed = (list & V::broadcast8(0x07)) | V::shr16(list & V::broadcast8(0x70), 1);
+    return {compressed, valid};
+}
+}  // namespace internal
+
+
+inline std::tuple<v512, u64> superpieceRays(Square sq) {
+    static const v512 offsets = v512{std::array<u8, 64>{
+      0x1F, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70,  // N
+      0x21, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,  // NE
+      0x12, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,  // E
+      0xF2, 0xF1, 0xE2, 0xD3, 0xC4, 0xB5, 0xA6, 0x97,  // SE
+      0xE1, 0xF0, 0xE0, 0xD0, 0xC0, 0xB0, 0xA0, 0x90,  // S
+      0xDF, 0xEF, 0xDE, 0xCD, 0xBC, 0xAB, 0x9A, 0x89,  // SW
+      0xEE, 0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9,  // W
+      0x0E, 0x0F, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A, 0x69,  // NW
+    }};
+
+    const v512 sq_vec       = v512::broadcast8(internal::expandSq(sq));
+    const v512 uncompressed = v512::add8(sq_vec, offsets);
+    return internal::compressCoords(uncompressed);
+}
+
+inline u64 superpieceAttacks(u64 occupied, u64 ray_valid) {
+    const u64 o = occupied | 0x8181818181818181;
+    const u64 x = o ^ (o - 0x0303030303030303);
+    return x & ray_valid;
+}
+
+inline u64 attackersFromRays(v512 ray_places) {
+    constexpr u8 k  = 1 << 0;
+    constexpr u8 wp = 1 << 1;
+    constexpr u8 bp = 1 << 2;
+    constexpr u8 n  = 1 << 3;
+    constexpr u8 b  = 1 << 4;
+    constexpr u8 r  = 1 << 5;
+    constexpr u8 q  = 1 << 6;
+
+    constexpr u8 diag       = b | q;
+    constexpr u8 orth       = r | q;
+    constexpr u8 orth_near  = r | q | k;
+    constexpr u8 horse      = n;
+    constexpr u8 wpawn_near = b | q | k | wp;
+    constexpr u8 bpawn_near = b | q | k | bp;
+
+    static const v128 ptype_to_bits{
+      std::array<u8, 16>{{0, wp, n, b, r, q, k, 0, 0, bp, n, b, r, q, k, 0}}};
+
+    static const v512 attacker_mask = v512{std::array<u8, 64>{
+      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // N
+      horse, bpawn_near, diag, diag, diag, diag, diag, diag,  // NE
+      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // E
+      horse, wpawn_near, diag, diag, diag, diag, diag, diag,  // SE
+      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // S
+      horse, wpawn_near, diag, diag, diag, diag, diag, diag,  // SW
+      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // W
+      horse, bpawn_near, diag, diag, diag, diag, diag, diag,  // NW
+    }};
+
+    const v512 bit_rays = v512::permute8(v512::shr16(ray_places, 4) & v512::broadcast8(0x0F),
+                                         v512::from128(ptype_to_bits));
+    return (bit_rays & attacker_mask).nonzero8();
+}
+
+}  // namespace rose::geometry

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -11,20 +11,22 @@ namespace Clockwork::geometry {
 
 namespace internal {
 // 00rrrfff → 0rrr0fff
-forceinline constexpr auto expandSq(Square sq) -> u8 { return sq.raw + (sq.raw & 0b111000); }
+forceinline constexpr auto expand_sq(Square sq) -> u8 {
+    return sq.raw + (sq.raw & 0b111000);
+}
 
 // 0rrr0fff → 00rrrfff
 template<typename V>
-forceinline auto compressCoords(V list) -> std::tuple<V, typename V::Mask8> {
-    const typename V::Mask8 valid = V::testn8(list, V::broadcast8(0x88));
-    const V compressed = (list & V::broadcast8(0x07)) | V::shr16(list & V::broadcast8(0x70), 1);
+forceinline auto compress_coords(V list) -> std::tuple<V, typename V::Mask8> {
+    typename V::Mask8 valid = V::testn8(list, V::broadcast8(0x88));
+    V compressed = (list & V::broadcast8(0x07)) | V::shr16(list & V::broadcast8(0x70), 1);
     return {compressed, valid};
 }
 }  // namespace internal
 
 
-inline std::tuple<v512, u64> superpieceRays(Square sq) {
-    static const v512 offsets = v512{std::array<u8, 64>{
+inline std::tuple<v512, u64> superpiece_rays(Square sq) {
+    static const v512 OFFSETS = v512{std::array<u8, 64>{
       0x1F, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70,  // N
       0x21, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,  // NE
       0x12, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,  // E
@@ -35,50 +37,50 @@ inline std::tuple<v512, u64> superpieceRays(Square sq) {
       0x0E, 0x0F, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A, 0x69,  // NW
     }};
 
-    const v512 sq_vec       = v512::broadcast8(internal::expandSq(sq));
-    const v512 uncompressed = v512::add8(sq_vec, offsets);
-    return internal::compressCoords(uncompressed);
+    v512 sq_vec       = v512::broadcast8(internal::expand_sq(sq));
+    v512 uncompressed = v512::add8(sq_vec, OFFSETS);
+    return internal::compress_coords(uncompressed);
 }
 
-inline u64 superpieceAttacks(u64 occupied, u64 ray_valid) {
-    const u64 o = occupied | 0x8181818181818181;
-    const u64 x = o ^ (o - 0x0303030303030303);
+inline u64 superpiece_attacks(u64 occupied, u64 ray_valid) {
+    u64 o = occupied | 0x8181818181818181;
+    u64 x = o ^ (o - 0x0303030303030303);
     return x & ray_valid;
 }
 
-inline u64 attackersFromRays(v512 ray_places) {
-    constexpr u8 k  = 1 << 0;
-    constexpr u8 wp = 1 << 1;
-    constexpr u8 bp = 1 << 2;
-    constexpr u8 n  = 1 << 3;
-    constexpr u8 b  = 1 << 4;
-    constexpr u8 r  = 1 << 5;
-    constexpr u8 q  = 1 << 6;
+inline u64 attackers_from_rays(v512 ray_places) {
+    constexpr u8 K  = 1 << 0;
+    constexpr u8 WP = 1 << 1;
+    constexpr u8 BP = 1 << 2;
+    constexpr u8 N  = 1 << 3;
+    constexpr u8 B  = 1 << 4;
+    constexpr u8 R  = 1 << 5;
+    constexpr u8 Q  = 1 << 6;
 
-    constexpr u8 diag       = b | q;
-    constexpr u8 orth       = r | q;
-    constexpr u8 orth_near  = r | q | k;
-    constexpr u8 horse      = n;
-    constexpr u8 wpawn_near = b | q | k | wp;
-    constexpr u8 bpawn_near = b | q | k | bp;
+    constexpr u8 DIAG       = B | Q;
+    constexpr u8 ORTH       = R | Q;
+    constexpr u8 ORTH_NEAR  = R | Q | K;
+    constexpr u8 HORSE      = N;
+    constexpr u8 WPAWN_NEAR = B | Q | K | WP;
+    constexpr u8 BPAWN_NEAR = B | Q | K | BP;
 
-    static const v128 ptype_to_bits{
-      std::array<u8, 16>{{0, wp, n, b, r, q, k, 0, 0, bp, n, b, r, q, k, 0}}};
+    static const v128 PTYPE_TO_BITS{
+      std::array<u8, 16>{{0, WP, N, B, R, Q, K, 0, 0, BP, N, B, R, Q, K, 0}}};
 
-    static const v512 attacker_mask = v512{std::array<u8, 64>{
-      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // N
-      horse, bpawn_near, diag, diag, diag, diag, diag, diag,  // NE
-      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // E
-      horse, wpawn_near, diag, diag, diag, diag, diag, diag,  // SE
-      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // S
-      horse, wpawn_near, diag, diag, diag, diag, diag, diag,  // SW
-      horse, orth_near,  orth, orth, orth, orth, orth, orth,  // W
-      horse, bpawn_near, diag, diag, diag, diag, diag, diag,  // NW
+    static const v512 ATTACKER_MASK = v512{std::array<u8, 64>{
+      HORSE, ORTH_NEAR,  ORTH, ORTH, ORTH, ORTH, ORTH, ORTH,  // N
+      HORSE, BPAWN_NEAR, DIAG, DIAG, DIAG, DIAG, DIAG, DIAG,  // NE
+      HORSE, ORTH_NEAR,  ORTH, ORTH, ORTH, ORTH, ORTH, ORTH,  // E
+      HORSE, WPAWN_NEAR, DIAG, DIAG, DIAG, DIAG, DIAG, DIAG,  // SE
+      HORSE, ORTH_NEAR,  ORTH, ORTH, ORTH, ORTH, ORTH, ORTH,  // S
+      HORSE, WPAWN_NEAR, DIAG, DIAG, DIAG, DIAG, DIAG, DIAG,  // SW
+      HORSE, ORTH_NEAR,  ORTH, ORTH, ORTH, ORTH, ORTH, ORTH,  // W
+      HORSE, BPAWN_NEAR, DIAG, DIAG, DIAG, DIAG, DIAG, DIAG,  // NW
     }};
 
-    const v512 bit_rays = v512::permute8(v512::shr16(ray_places, 4) & v512::broadcast8(0x0F),
-                                         v512::from128(ptype_to_bits));
-    return (bit_rays & attacker_mask).nonzero8();
+    v512 bit_rays = v512::permute8(v512::shr16(ray_places, 4) & v512::broadcast8(0x0F),
+                                   v512::from128(PTYPE_TO_BITS));
+    return (bit_rays & ATTACKER_MASK).nonzero8();
 }
 
 }  // namespace rose::geometry

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -8,56 +8,52 @@ std::optional<Move> Move::parse(std::string_view str, const Position& ctx) {
     if (str.size() != 4 && str.size() != 5)
         return std::nullopt;
 
-    const auto from = Square::parse(str.substr(0, 2));
+    auto from = Square::parse(str.substr(0, 2));
     if (!from)
         return std::nullopt;
 
-    const auto to = Square::parse(str.substr(2, 2));
+    auto to = Square::parse(str.substr(2, 2));
     if (!to)
         return std::nullopt;
 
-    const Place src = ctx.board()[*from];
-    const Place dst = ctx.board()[*to];
+    Place src = ctx.board()[*from];
+    Place dst = ctx.board()[*to];
 
-    const PieceType ptype   = src.ptype();
-    const bool      capture = !dst.isEmpty();
+    PieceType ptype   = src.ptype();
+    bool      capture = !dst.is_empty();
 
-    if (src.color() != ctx.activeColor())
+    if (src.color() != ctx.active_color())
         return std::nullopt;
 
-    if (str.size() == 4)
-    {
-        if (ptype == PieceType::pawn)
-        {
-            if (ctx.enPassant() == *to)
-                return Move(*from, *to, MoveFlags::en_passant);
+    if (str.size() == 4) {
+        if (ptype == PieceType::Pawn) {
+            if (ctx.en_passant() == *to)
+                return Move(*from, *to, MoveFlags::EnPassant);
         }
-        if (ptype == PieceType::king)
-        {
-            // TOOD: FRC
+        if (ptype == PieceType::King) {
+            // TODO: FRC
             if (from->file() == 4 && to->file() == 2)
-                return Move(*from, ctx.rookInfo(ctx.activeColor()).aside, MoveFlags::castle);
+                return Move(*from, ctx.rook_info(ctx.active_color()).aside, MoveFlags::Castle);
             if (from->file() == 4 && to->file() == 6)
-                return Move(*from, ctx.rookInfo(ctx.activeColor()).hside, MoveFlags::castle);
+                return Move(*from, ctx.rook_info(ctx.active_color()).hside, MoveFlags::Castle);
         }
-        return Move(*from, *to, capture ? MoveFlags::capture_bit : MoveFlags::normal);
+        return Move(*from, *to, capture ? MoveFlags::CaptureBit : MoveFlags::Normal);
     }
 
     // This check needs to be here because castling is king captures rook in FRC.
-    if (capture && dst.color() == ctx.activeColor())
+    if (capture && dst.color() == ctx.active_color())
         return std::nullopt;
 
-    const auto mf = [&]() -> std::optional<MoveFlags> {
-        switch (str[4])
-        {
+    auto mf = [&]() -> std::optional<MoveFlags> {
+        switch (str[4]) {
         case 'q' :
-            return capture ? MoveFlags::promo_queen_capture : MoveFlags::promo_queen;
+            return capture ? MoveFlags::PromoQueenCapture : MoveFlags::PromoQueen;
         case 'n' :
-            return capture ? MoveFlags::promo_knight_capture : MoveFlags::promo_knight;
+            return capture ? MoveFlags::PromoKnightCapture : MoveFlags::PromoKnight;
         case 'r' :
-            return capture ? MoveFlags::promo_rook_capture : MoveFlags::promo_rook;
+            return capture ? MoveFlags::PromoRookCapture : MoveFlags::PromoRook;
         case 'b' :
-            return capture ? MoveFlags::promo_bishop_capture : MoveFlags::promo_bishop;
+            return capture ? MoveFlags::PromoBishopCapture : MoveFlags::PromoBishop;
         default :
             return std::nullopt;
         }

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1,0 +1,70 @@
+#include "move.hpp"
+
+#include "position.hpp"
+
+namespace Clockwork {
+
+std::optional<Move> Move::parse(std::string_view str, const Position& ctx) {
+    if (str.size() != 4 && str.size() != 5)
+        return std::nullopt;
+
+    const auto from = Square::parse(str.substr(0, 2));
+    if (!from)
+        return std::nullopt;
+
+    const auto to = Square::parse(str.substr(2, 2));
+    if (!to)
+        return std::nullopt;
+
+    const Place src = ctx.board()[*from];
+    const Place dst = ctx.board()[*to];
+
+    const PieceType ptype   = src.ptype();
+    const bool      capture = !dst.isEmpty();
+
+    if (src.color() != ctx.activeColor())
+        return std::nullopt;
+
+    if (str.size() == 4)
+    {
+        if (ptype == PieceType::pawn)
+        {
+            if (ctx.enPassant() == *to)
+                return Move(*from, *to, MoveFlags::en_passant);
+        }
+        if (ptype == PieceType::king)
+        {
+            // TOOD: FRC
+            if (from->file() == 4 && to->file() == 2)
+                return Move(*from, ctx.rookInfo(ctx.activeColor()).aside, MoveFlags::castle);
+            if (from->file() == 4 && to->file() == 6)
+                return Move(*from, ctx.rookInfo(ctx.activeColor()).hside, MoveFlags::castle);
+        }
+        return Move(*from, *to, capture ? MoveFlags::capture_bit : MoveFlags::normal);
+    }
+
+    // This check needs to be here because castling is king captures rook in FRC.
+    if (capture && dst.color() == ctx.activeColor())
+        return std::nullopt;
+
+    const auto mf = [&]() -> std::optional<MoveFlags> {
+        switch (str[4])
+        {
+        case 'q' :
+            return capture ? MoveFlags::promo_queen_capture : MoveFlags::promo_queen;
+        case 'n' :
+            return capture ? MoveFlags::promo_knight_capture : MoveFlags::promo_knight;
+        case 'r' :
+            return capture ? MoveFlags::promo_rook_capture : MoveFlags::promo_rook;
+        case 'b' :
+            return capture ? MoveFlags::promo_bishop_capture : MoveFlags::promo_bishop;
+        default :
+            return std::nullopt;
+        }
+    }();
+    if (!mf)
+        return std::nullopt;
+    return Move(*from, *to, *mf);
+}
+
+}

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -5,10 +5,11 @@
 #include "common.hpp"
 
 #include <optional>
+#include <string_view>
 
 namespace Clockwork {
 
-static_assert(static_cast<u16>(PieceType::Knight) == 1);
+static_assert(static_cast<u16>(PieceType::Knight) == 2);
 
 enum class MoveFlags : u16 {
     Normal             = 0b0000 << 12,
@@ -16,30 +17,30 @@ enum class MoveFlags : u16 {
     CaptureBit         = 0b0100 << 12,
     EnPassant          = 0b0110 << 12,
     PromotionBit       = 0b1000 << 12,
-    PromoKnight        = (0b1000 | (static_cast<u16>(PieceType::Knight) - 1)) << 12,
-    PromoBishop        = (0b1000 | (static_cast<u16>(PieceType::Bishop) - 1)) << 12,
-    PromoRook          = (0b1000 | (static_cast<u16>(PieceType::Rook) - 1)) << 12,
-    PromoQueen         = (0b1000 | (static_cast<u16>(PieceType::Queen) - 1)) << 12,
+    PromoKnight        = (0b1000 | (static_cast<u16>(PieceType::Knight) - 2)) << 12,
+    PromoBishop        = (0b1000 | (static_cast<u16>(PieceType::Bishop) - 2)) << 12,
+    PromoRook          = (0b1000 | (static_cast<u16>(PieceType::Rook) - 2)) << 12,
+    PromoQueen         = (0b1000 | (static_cast<u16>(PieceType::Queen) - 2)) << 12,
     PromoCapture       = 0b1100 << 12,
-    PromoKnightCapture = (0b1100 | (static_cast<u16>(PieceType::Knight) - 1)) << 12,
-    PromoBishopCapture = (0b1100 | (static_cast<u16>(PieceType::Bishop) - 1)) << 12,
-    PromoRookCapture   = (0b1100 | (static_cast<u16>(PieceType::Rook) - 1)) << 12,
-    PromoQueenCapture  = (0b1100 | (static_cast<u16>(PieceType::Queen) - 1)) << 12,
+    PromoKnightCapture = (0b1100 | (static_cast<u16>(PieceType::Knight) - 2)) << 12,
+    PromoBishopCapture = (0b1100 | (static_cast<u16>(PieceType::Bishop) - 2)) << 12,
+    PromoRookCapture   = (0b1100 | (static_cast<u16>(PieceType::Rook) - 2)) << 12,
+    PromoQueenCapture  = (0b1100 | (static_cast<u16>(PieceType::Queen) - 2)) << 12,
 };
 
 struct Move {
     u16 raw;
 
     constexpr Move(Square from, Square to, MoveFlags flags = MoveFlags::Normal) {
-        raw = from.raw | (to.raw << 6) | static_cast<u16>(flags);
+        raw = static_cast<u16>(from.raw | (to.raw << 6) | static_cast<u16>(flags));
     }
 
     [[nodiscard]] constexpr Square from() const {
-        return static_cast<Square>(raw & 0x3F);
+        return Square{static_cast<u8>(raw & 0x3F)};
     }
 
     [[nodiscard]] constexpr Square to() const {
-        return static_cast<Square>((raw >> 6) & 0x3F);
+        return Square{static_cast<u8>((raw >> 6) & 0x3F)};
     }
 
     [[nodiscard]] constexpr MoveFlags flags() const {
@@ -55,22 +56,30 @@ struct Move {
     }
 
     [[nodiscard]] constexpr std::optional<PieceType> promo() const {
-        switch (flags()) {
-        case MoveFlags::PromoKnight :
-            return PieceType::Knight;
-        case MoveFlags::PromoBishop :
-            return PieceType::Bishop;
-        case MoveFlags::PromoRook :
-            return PieceType::Rook;
-        case MoveFlags::PromoQueen :
-            return PieceType::Queen;
-        default :
-            return std::nullopt;
-        }
+        if (!is_promotion())
+            returns std::nullopt;
+
+        static_assert(static_cast<u16>(PieceType::Knight) == 2);
+        return static_cast<PieceType>(((raw >> 12) & 0b0011) + 2);
     }
 
+    static std::optional<Move> parse(std::string_view str, const Position& context);
+
     friend std::ostream& operator<<(std::ostream& os, Move mv) {
-        os << mv.from() << mv.to();
+        os << mv.from();
+
+        if (mv.flags() == MoveFlags::Castle) {
+            // TODO: FRC
+            if (mv.to().file() < mv.from().file())
+                os << 'c';
+            else
+                os << 'g';
+            os << mv.to().rank() + 1;
+        }
+        else {
+            os << mv.to();
+        }
+
         if (auto promo = mv.promo()) {
             os << piece_char(*promo);
         }

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -9,6 +9,8 @@
 
 namespace Clockwork {
 
+struct Position;
+
 static_assert(static_cast<u16>(PieceType::Knight) == 2);
 
 enum class MoveFlags : u16 {
@@ -30,6 +32,8 @@ enum class MoveFlags : u16 {
 
 struct Move {
     u16 raw;
+
+    Move() = default;
 
     constexpr Move(Square from, Square to, MoveFlags flags = MoveFlags::Normal) {
         raw = static_cast<u16>(from.raw | (to.raw << 6) | static_cast<u16>(flags));
@@ -57,7 +61,7 @@ struct Move {
 
     [[nodiscard]] constexpr std::optional<PieceType> promo() const {
         if (!is_promotion())
-            returns std::nullopt;
+            return std::nullopt;
 
         static_assert(static_cast<u16>(PieceType::Knight) == 2);
         return static_cast<PieceType>(((raw >> 12) & 0b0011) + 2);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1,0 +1,142 @@
+#include "movegen.hpp"
+
+#include <bit>
+#include <tuple>
+
+#include "common.hpp"
+#include "move.hpp"
+#include "position.hpp"
+#include "util/types.hpp"
+
+namespace Clockwork {
+
+static std::tuple<u64, u64, u64, int, int> validPawns(Color color, u64 bb, u64 empty, u64 dests) {
+    switch (color)
+    {
+    case Color::white : {
+        const u64 single = bb & ((empty & dests) >> 8);
+        return {single & 0x0000FFFFFFFFFF00,
+                bb & (empty >> 8) & ((empty & dests) >> 16) & 0x000000000000FF00,
+                single & 0x00FF000000000000, 8, 16};
+    }
+    case Color::black : {
+        const u64 single = bb & ((empty & dests) << 8);
+        return {single & 0x00FFFFFFFFFF0000,
+                bb & (empty << 8) & ((empty & dests) << 16) & 0x00FF000000000000,
+                single & 0x000000000000FF00, -8, -16};
+    }
+    }
+}
+
+void MoveGen::generateMoves(MoveList& moves) {
+    const Color active_color = m_position.activeColor();
+
+    const u64 empty = m_position.board().getEmptyBitboard();
+    const u64 enemy = m_position.board().getColorBitboard(invert(active_color));
+
+    const Wordboard& at = m_position.attackTable(active_color);
+
+    const u64 active = m_position.attackTable(active_color).getAttackedBitboard();
+    const u64 danger = m_position.attackTable(invert(active_color)).getAttackedBitboard();
+
+    const u16 valid_plist   = m_position.pieceList(active_color).maskValid();
+    const u16 king_mask     = 1;
+    const u16 pawn_mask     = m_position.pieceList(active_color).maskEq(PieceType::pawn);
+    const u16 non_pawn_mask = valid_plist & ~pawn_mask;
+
+    // En passant
+    if (const Square ep = m_position.enPassant(); ep.isValid())
+        write(moves, ep, at[ep] & pawn_mask, MoveFlags::en_passant);
+
+    // Undefended non-pawn captures
+    write(moves, at, active & enemy & ~danger, non_pawn_mask, MoveFlags::capture_bit);
+    // Defended non-pawn captures
+    write(moves, at, active & enemy & danger, non_pawn_mask & ~king_mask, MoveFlags::capture_bit);
+
+    const u64 promo_zone = static_cast<u64>(0xFF) << (active_color == Color::white ? 56 : 0);
+    // Capture-with-promotion
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_queen_capture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_knight_capture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_rook_capture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_bishop_capture);
+    // Non-promotion pawn captures
+    write(moves, at, active & enemy & ~promo_zone, pawn_mask, MoveFlags::capture_bit);
+
+    // Castling
+    // TODO: FRC
+    {
+        const int      color_shift = active_color == Color::white ? 0 : 56;
+        const Square   king_sq     = m_position.kingSq(active_color);
+        const RookInfo rook_info   = m_position.rookInfo(active_color);
+        if (rook_info.aside.isValid())
+        {
+            const u64 clear      = empty | king_sq.toBitboard() | rook_info.aside.toBitboard();
+            const u8  rank_empty = static_cast<u8>(clear >> color_shift);
+            const u8  rank_safe  = static_cast<u8>(~danger >> color_shift);
+            if ((rank_empty & 0x1F) == 0x1F && (rank_safe & 0x1C) == 0x1C)
+                moves.push_back(Move{king_sq, rook_info.aside, MoveFlags::castle});
+        }
+        if (rook_info.hside.isValid())
+        {
+            const u64 clear      = empty | king_sq.toBitboard() | rook_info.hside.toBitboard();
+            const u8  rank_empty = static_cast<u8>(clear >> color_shift);
+            const u8  rank_safe  = static_cast<u8>(~danger >> color_shift);
+            if ((rank_empty & 0xF0) == 0xF0 && (rank_safe & 0x70) == 0x70)
+                moves.push_back(Move{king_sq, rook_info.hside, MoveFlags::castle});
+        }
+    }
+
+    // Undefended non-pawn quiets
+    write(moves, at, active & empty & ~danger, non_pawn_mask, MoveFlags::normal);
+
+    // Defended non-pawn quiets
+    write(moves, at, active & empty & danger, non_pawn_mask & ~king_mask, MoveFlags::normal);
+
+    // Pawn quiets
+    {
+        const u64 bb = m_position.board().bitboardFor(active_color, PieceType::pawn);
+        const auto [single_push, double_push, promo, single_shift, double_shift] =
+          validPawns(active_color, bb, empty, empty);
+
+        writePawn(moves, promo, single_shift, MoveFlags::promo_queen);
+        writePawn(moves, promo, single_shift, MoveFlags::promo_knight);
+        writePawn(moves, promo, single_shift, MoveFlags::promo_rook);
+        writePawn(moves, promo, single_shift, MoveFlags::promo_bishop);
+
+        writePawn(moves, single_push, single_shift, MoveFlags::normal);
+
+        writePawn(moves, double_push, double_shift, MoveFlags::normal);
+    }
+}
+
+void MoveGen::write(MoveList& moves, Square dest, u16 piecemask, MoveFlags mf) {
+    if (!piecemask)
+        return;
+
+    const usize count = std::popcount(piecemask);
+    for (u8 i = 0; i < count; i++, piecemask &= piecemask - 1)
+    {
+        const PieceId id{static_cast<u8>(std::countr_zero(piecemask))};
+        const Square  src = m_position.pieceListSq(m_active_color)[id];
+        moves.push_back(Move{src, dest, mf});
+    }
+}
+
+void MoveGen::write(MoveList& moves, const Wordboard& at, u64 bb, u16 piecemask, MoveFlags mf) {
+    for (; bb != 0; bb &= bb - 1)
+    {
+        const Square dest{static_cast<u8>(std::countr_zero(bb))};
+        write(moves, dest, piecemask & at[dest], mf);
+    }
+}
+
+void MoveGen::writePawn(MoveList& moves, u64 bb, int shift, MoveFlags mf) {
+    for (; bb != 0; bb &= bb - 1)
+    {
+        const Square src{static_cast<u8>(std::countr_zero(bb))};
+        const Square dest{static_cast<u8>(src.raw + shift)};
+        moves.push_back(Move{src, dest, mf});
+    }
+}
+
+}

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -10,17 +10,16 @@
 
 namespace Clockwork {
 
-static std::tuple<u64, u64, u64, int, int> validPawns(Color color, u64 bb, u64 empty, u64 dests) {
-    switch (color)
-    {
-    case Color::white : {
-        const u64 single = bb & ((empty & dests) >> 8);
+static std::tuple<u64, u64, u64, int, int> valid_pawns(Color color, u64 bb, u64 empty, u64 dests) {
+    switch (color) {
+    case Color::White : {
+        u64 single = bb & ((empty & dests) >> 8);
         return {single & 0x0000FFFFFFFFFF00,
                 bb & (empty >> 8) & ((empty & dests) >> 16) & 0x000000000000FF00,
                 single & 0x00FF000000000000, 8, 16};
     }
-    case Color::black : {
-        const u64 single = bb & ((empty & dests) << 8);
+    case Color::Black : {
+        u64 single = bb & ((empty & dests) << 8);
         return {single & 0x00FFFFFFFFFF0000,
                 bb & (empty << 8) & ((empty & dests) << 16) & 0x00FF000000000000,
                 single & 0x000000000000FF00, -8, -16};
@@ -28,84 +27,82 @@ static std::tuple<u64, u64, u64, int, int> validPawns(Color color, u64 bb, u64 e
     }
 }
 
-void MoveGen::generateMoves(MoveList& moves) {
-    const Color active_color = m_position.activeColor();
+void MoveGen::generate_moves(MoveList& moves) {
+    Color active_color = m_position.active_color();
 
-    const u64 empty = m_position.board().getEmptyBitboard();
-    const u64 enemy = m_position.board().getColorBitboard(invert(active_color));
+    u64 empty = m_position.board().get_empty_bitboard();
+    u64 enemy = m_position.board().get_color_bitboard(invert(active_color));
 
-    const Wordboard& at = m_position.attackTable(active_color);
+    const Wordboard& at = m_position.attack_table(active_color);
 
-    const u64 active = m_position.attackTable(active_color).getAttackedBitboard();
-    const u64 danger = m_position.attackTable(invert(active_color)).getAttackedBitboard();
+    u64 active = m_position.attack_table(active_color).get_attacked_bitboard();
+    u64 danger = m_position.attack_table(invert(active_color)).get_attacked_bitboard();
 
-    const u16 valid_plist   = m_position.pieceList(active_color).maskValid();
-    const u16 king_mask     = 1;
-    const u16 pawn_mask     = m_position.pieceList(active_color).maskEq(PieceType::pawn);
-    const u16 non_pawn_mask = valid_plist & ~pawn_mask;
+    u16 valid_plist   = m_position.piece_list(active_color).mask_valid();
+    u16 king_mask     = 1;
+    u16 pawn_mask     = m_position.piece_list(active_color).mask_eq(PieceType::Pawn);
+    u16 non_pawn_mask = valid_plist & ~pawn_mask;
 
     // En passant
-    if (const Square ep = m_position.enPassant(); ep.isValid())
-        write(moves, ep, at[ep] & pawn_mask, MoveFlags::en_passant);
+    if (Square ep = m_position.en_passant(); ep.is_valid())
+        write(moves, ep, at[ep] & pawn_mask, MoveFlags::EnPassant);
 
     // Undefended non-pawn captures
-    write(moves, at, active & enemy & ~danger, non_pawn_mask, MoveFlags::capture_bit);
+    write(moves, at, active & enemy & ~danger, non_pawn_mask, MoveFlags::CaptureBit);
     // Defended non-pawn captures
-    write(moves, at, active & enemy & danger, non_pawn_mask & ~king_mask, MoveFlags::capture_bit);
+    write(moves, at, active & enemy & danger, non_pawn_mask & ~king_mask, MoveFlags::CaptureBit);
 
-    const u64 promo_zone = static_cast<u64>(0xFF) << (active_color == Color::white ? 56 : 0);
+    u64 promo_zone = static_cast<u64>(0xFF) << (active_color == Color::White ? 56 : 0);
     // Capture-with-promotion
-    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_queen_capture);
-    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_knight_capture);
-    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_rook_capture);
-    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::promo_bishop_capture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::PromoQueenCapture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::PromoKnightCapture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::PromoRookCapture);
+    write(moves, at, active & enemy & promo_zone, pawn_mask, MoveFlags::PromoBishopCapture);
     // Non-promotion pawn captures
-    write(moves, at, active & enemy & ~promo_zone, pawn_mask, MoveFlags::capture_bit);
+    write(moves, at, active & enemy & ~promo_zone, pawn_mask, MoveFlags::CaptureBit);
 
     // Castling
     // TODO: FRC
     {
-        const int      color_shift = active_color == Color::white ? 0 : 56;
-        const Square   king_sq     = m_position.kingSq(active_color);
-        const RookInfo rook_info   = m_position.rookInfo(active_color);
-        if (rook_info.aside.isValid())
-        {
-            const u64 clear      = empty | king_sq.toBitboard() | rook_info.aside.toBitboard();
-            const u8  rank_empty = static_cast<u8>(clear >> color_shift);
-            const u8  rank_safe  = static_cast<u8>(~danger >> color_shift);
+        int      color_shift = active_color == Color::White ? 0 : 56;
+        Square   king_sq     = m_position.king_sq(active_color);
+        RookInfo rook_info   = m_position.rook_info(active_color);
+        if (rook_info.aside.is_valid()) {
+            u64 clear      = empty | king_sq.to_bitboard() | rook_info.aside.to_bitboard();
+            u8  rank_empty = static_cast<u8>(clear >> color_shift);
+            u8  rank_safe  = static_cast<u8>(~danger >> color_shift);
             if ((rank_empty & 0x1F) == 0x1F && (rank_safe & 0x1C) == 0x1C)
-                moves.push_back(Move{king_sq, rook_info.aside, MoveFlags::castle});
+                moves.push_back(Move{king_sq, rook_info.aside, MoveFlags::Castle});
         }
-        if (rook_info.hside.isValid())
-        {
-            const u64 clear      = empty | king_sq.toBitboard() | rook_info.hside.toBitboard();
-            const u8  rank_empty = static_cast<u8>(clear >> color_shift);
-            const u8  rank_safe  = static_cast<u8>(~danger >> color_shift);
+        if (rook_info.hside.is_valid()) {
+            u64 clear      = empty | king_sq.to_bitboard() | rook_info.hside.to_bitboard();
+            u8  rank_empty = static_cast<u8>(clear >> color_shift);
+            u8  rank_safe  = static_cast<u8>(~danger >> color_shift);
             if ((rank_empty & 0xF0) == 0xF0 && (rank_safe & 0x70) == 0x70)
-                moves.push_back(Move{king_sq, rook_info.hside, MoveFlags::castle});
+                moves.push_back(Move{king_sq, rook_info.hside, MoveFlags::Castle});
         }
     }
 
     // Undefended non-pawn quiets
-    write(moves, at, active & empty & ~danger, non_pawn_mask, MoveFlags::normal);
+    write(moves, at, active & empty & ~danger, non_pawn_mask, MoveFlags::Normal);
 
     // Defended non-pawn quiets
-    write(moves, at, active & empty & danger, non_pawn_mask & ~king_mask, MoveFlags::normal);
+    write(moves, at, active & empty & danger, non_pawn_mask & ~king_mask, MoveFlags::Normal);
 
     // Pawn quiets
     {
-        const u64 bb = m_position.board().bitboardFor(active_color, PieceType::pawn);
-        const auto [single_push, double_push, promo, single_shift, double_shift] =
-          validPawns(active_color, bb, empty, empty);
+        u64 bb = m_position.board().bitboard_for(active_color, PieceType::Pawn);
+        auto [single_push, double_push, promo, single_shift, double_shift] =
+          valid_pawns(active_color, bb, empty, empty);
 
-        writePawn(moves, promo, single_shift, MoveFlags::promo_queen);
-        writePawn(moves, promo, single_shift, MoveFlags::promo_knight);
-        writePawn(moves, promo, single_shift, MoveFlags::promo_rook);
-        writePawn(moves, promo, single_shift, MoveFlags::promo_bishop);
+        write_pawn(moves, promo, single_shift, MoveFlags::PromoQueen);
+        write_pawn(moves, promo, single_shift, MoveFlags::PromoKnight);
+        write_pawn(moves, promo, single_shift, MoveFlags::PromoRook);
+        write_pawn(moves, promo, single_shift, MoveFlags::PromoBishop);
 
-        writePawn(moves, single_push, single_shift, MoveFlags::normal);
+        write_pawn(moves, single_push, single_shift, MoveFlags::Normal);
 
-        writePawn(moves, double_push, double_shift, MoveFlags::normal);
+        write_pawn(moves, double_push, double_shift, MoveFlags::Normal);
     }
 }
 
@@ -113,28 +110,25 @@ void MoveGen::write(MoveList& moves, Square dest, u16 piecemask, MoveFlags mf) {
     if (!piecemask)
         return;
 
-    const usize count = std::popcount(piecemask);
-    for (u8 i = 0; i < count; i++, piecemask &= piecemask - 1)
-    {
-        const PieceId id{static_cast<u8>(std::countr_zero(piecemask))};
-        const Square  src = m_position.pieceListSq(m_active_color)[id];
+    usize count = std::popcount(piecemask);
+    for (u8 i = 0; i < count; i++, piecemask &= piecemask - 1) {
+        PieceId id{static_cast<u8>(std::countr_zero(piecemask))};
+        Square  src = m_position.piece_list_sq(m_active_color)[id];
         moves.push_back(Move{src, dest, mf});
     }
 }
 
 void MoveGen::write(MoveList& moves, const Wordboard& at, u64 bb, u16 piecemask, MoveFlags mf) {
-    for (; bb != 0; bb &= bb - 1)
-    {
-        const Square dest{static_cast<u8>(std::countr_zero(bb))};
+    for (; bb != 0; bb &= bb - 1) {
+        Square dest{static_cast<u8>(std::countr_zero(bb))};
         write(moves, dest, piecemask & at[dest], mf);
     }
 }
 
-void MoveGen::writePawn(MoveList& moves, u64 bb, int shift, MoveFlags mf) {
-    for (; bb != 0; bb &= bb - 1)
-    {
-        const Square src{static_cast<u8>(std::countr_zero(bb))};
-        const Square dest{static_cast<u8>(src.raw + shift)};
+void MoveGen::write_pawn(MoveList& moves, u64 bb, int shift, MoveFlags mf) {
+    for (; bb != 0; bb &= bb - 1) {
+        Square src{static_cast<u8>(std::countr_zero(bb))};
+        Square dest{static_cast<u8>(src.raw + shift)};
         moves.push_back(Move{src, dest, mf});
     }
 }

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -6,6 +6,7 @@
 #include "common.hpp"
 #include "move.hpp"
 #include "position.hpp"
+#include "util/bit.hpp"
 #include "util/types.hpp"
 
 namespace Clockwork {
@@ -111,7 +112,7 @@ void MoveGen::write(MoveList& moves, Square dest, u16 piecemask, MoveFlags mf) {
         return;
 
     usize count = std::popcount(piecemask);
-    for (u8 i = 0; i < count; i++, piecemask &= piecemask - 1) {
+    for (u8 i = 0; i < count; i++, piecemask = clear_lowest_bit(piecemask)) {
         PieceId id{static_cast<u8>(std::countr_zero(piecemask))};
         Square  src = m_position.piece_list_sq(m_active_color)[id];
         moves.push_back(Move{src, dest, mf});
@@ -119,14 +120,14 @@ void MoveGen::write(MoveList& moves, Square dest, u16 piecemask, MoveFlags mf) {
 }
 
 void MoveGen::write(MoveList& moves, const Wordboard& at, u64 bb, u16 piecemask, MoveFlags mf) {
-    for (; bb != 0; bb &= bb - 1) {
+    for (; bb != 0; bb = clear_lowest_bit(bb)) {
         Square dest{static_cast<u8>(std::countr_zero(bb))};
         write(moves, dest, piecemask & at[dest], mf);
     }
 }
 
 void MoveGen::write_pawn(MoveList& moves, u64 bb, int shift, MoveFlags mf) {
-    for (; bb != 0; bb &= bb - 1) {
+    for (; bb != 0; bb = clear_lowest_bit(bb)) {
         Square src{static_cast<u8>(std::countr_zero(bb))};
         Square dest{static_cast<u8>(src.raw + shift)};
         moves.push_back(Move{src, dest, mf});

--- a/src/movegen.hpp
+++ b/src/movegen.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "move.hpp"
+#include "position.hpp"
+#include "square.hpp"
+#include "util/static_vector.hpp"
+
+namespace Clockwork {
+
+using MoveList = StaticVector<Move, 256>;
+
+class MoveGen {
+   public:
+    explicit MoveGen(const Position& position) :
+        m_active_color(position.activeColor()),
+        m_position(position) {}
+
+    void generateMoves(MoveList& moves);
+
+   private:
+    void write(MoveList& moves, Square sq, u16 piecemask, MoveFlags mf);
+    void write(MoveList& moves, const Wordboard& at, u64 bb, u16 piecemask, MoveFlags mf);
+    void writePawn(MoveList& moves, u64 bb, int shift, MoveFlags mf);
+
+    const Color     m_active_color;
+    const Position& m_position;
+};
+
+}

--- a/src/movegen.hpp
+++ b/src/movegen.hpp
@@ -10,19 +10,20 @@ namespace Clockwork {
 using MoveList = StaticVector<Move, 256>;
 
 class MoveGen {
-   public:
+public:
     explicit MoveGen(const Position& position) :
-        m_active_color(position.activeColor()),
-        m_position(position) {}
+        m_active_color(position.active_color()),
+        m_position(position) {
+    }
 
-    void generateMoves(MoveList& moves);
+    void generate_moves(MoveList& moves);
 
-   private:
+private:
     void write(MoveList& moves, Square sq, u16 piecemask, MoveFlags mf);
     void write(MoveList& moves, const Wordboard& at, u64 bb, u16 piecemask, MoveFlags mf);
-    void writePawn(MoveList& moves, u64 bb, int shift, MoveFlags mf);
+    void write_pawn(MoveList& moves, u64 bb, int shift, MoveFlags mf);
 
-    const Color     m_active_color;
+    Color           m_active_color;
     const Position& m_position;
 };
 

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+
+#include "movegen.hpp"
+#include "position.hpp"
+#include "util/types.hpp"
+
+namespace Clockwork {
+
+template<bool print>
+static u64 core(const Position& position, usize depth) {
+    if (depth == 0)
+        return 1;
+
+    u64 result = 0;
+
+    MoveList moves;
+    MoveGen  movegen{position};
+    movegen.generateMoves(moves);
+
+    for (Move m : moves)
+    {
+        const Position new_position = position.move(m);
+        if (!new_position.isValid())
+            continue;
+
+        const u64 child = core<false>(new_position, depth - 1);
+
+        if constexpr (print)
+            std::cout << m << ": " << child << std::endl;
+
+        result += child;
+    }
+
+    return result;
+}
+
+u64 perft(const Position& position, usize depth) { return core<false>(position, depth); }
+
+void splitPerft(const Position& position, usize depth) {
+    const u64 total = core<true>(position, depth);
+    std::cout << "total: " << total << std::endl;
+}
+
+}

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -15,15 +15,14 @@ static u64 core(const Position& position, usize depth) {
 
     MoveList moves;
     MoveGen  movegen{position};
-    movegen.generateMoves(moves);
+    movegen.generate_moves(moves);
 
-    for (Move m : moves)
-    {
-        const Position new_position = position.move(m);
-        if (!new_position.isValid())
+    for (Move m : moves) {
+        Position new_position = position.move(m);
+        if (!new_position.is_valid())
             continue;
 
-        const u64 child = core<false>(new_position, depth - 1);
+        u64 child = core<false>(new_position, depth - 1);
 
         if constexpr (print)
             std::cout << m << ": " << child << std::endl;
@@ -34,10 +33,12 @@ static u64 core(const Position& position, usize depth) {
     return result;
 }
 
-u64 perft(const Position& position, usize depth) { return core<false>(position, depth); }
+u64 perft(const Position& position, usize depth) {
+    return core<false>(position, depth);
+}
 
-void splitPerft(const Position& position, usize depth) {
-    const u64 total = core<true>(position, depth);
+void split_perft(const Position& position, usize depth) {
+    u64 total = core<true>(position, depth);
     std::cout << "total: " << total << std::endl;
 }
 

--- a/src/perft.hpp
+++ b/src/perft.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "position.hpp"
+#include "util/types.hpp"
+
+namespace Clockwork {
+
+u64 perft(const Position& position, usize depth);
+
+void splitPerft(const Position& position, usize depth);
+
+}

--- a/src/perft.hpp
+++ b/src/perft.hpp
@@ -7,6 +7,6 @@ namespace Clockwork {
 
 u64 perft(const Position& position, usize depth);
 
-void splitPerft(const Position& position, usize depth);
+void split_perft(const Position& position, usize depth);
 
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1,0 +1,424 @@
+#include "position.hpp"
+
+#include <array>
+#include <bit>
+#include <sstream>
+#include <iostream>
+
+#include "board.hpp"
+#include "geometry.hpp"
+#include "util/types.hpp"
+
+namespace Clockwork {
+
+Position Position::move(Move m) const {
+    Position new_pos = *this;
+
+    const Square from  = m.from();
+    const Square to    = m.to();
+    const Place  src   = m_board[from];
+    const Place  dst   = m_board[to];
+    const usize  color = static_cast<usize>(m_active_color);
+
+    if (m_enpassant.isValid())
+        new_pos.m_enpassant = Square::invalid();
+
+    const auto check_src_castling_rights = [&] {
+        if (src.ptype() == PieceType::rook)
+            new_pos.m_rook_info[color].unset(from);
+        else if (src.ptype() == PieceType::king)
+            new_pos.m_rook_info[color].clear();
+    };
+
+    const auto check_dst_castling_rights = [&] {
+        if (dst.ptype() == PieceType::rook)
+            new_pos.m_rook_info[!color].unset(to);
+    };
+
+    switch (m.flags())
+    {
+    case MoveFlags::normal :
+        new_pos.m_board[from]                    = Place::empty();
+        new_pos.m_board[to]                      = src;
+        new_pos.m_piece_list_sq[color][src.id()] = to;
+        if (src.ptype() == PieceType::pawn)
+        {
+            new_pos.m_50mr = 0;
+            if (from.raw - to.raw == 16 || to.raw - from.raw == 16)
+                new_pos.m_enpassant = Square{static_cast<u8>((from.raw + to.raw) / 2)};
+        }
+        else
+        {
+            new_pos.m_50mr++;
+            check_src_castling_rights();
+        }
+        break;
+    case MoveFlags::capture_bit :
+        new_pos.m_board[from]                     = Place::empty();
+        new_pos.m_board[to]                       = src;
+        new_pos.m_piece_list_sq[color][src.id()]  = to;
+        new_pos.m_piece_list_sq[!color][dst.id()] = Square::invalid();
+        new_pos.m_piece_list[!color][dst.id()]    = PieceType::none;
+        new_pos.m_50mr                            = 0;
+        check_src_castling_rights();
+        check_dst_castling_rights();
+        break;
+    case MoveFlags::castle : {
+        const bool    aside     = to.file() < from.file();
+        const PieceId king_id   = PieceId{0};  // == src.id()
+        const PieceId rook_id   = dst.id();
+        const Square  king_from = from;
+        const Square  rook_from = to;
+        const Square  king_to   = Square::fromFileAndRank(aside ? 2 : 6, from.rank());
+        const Square  rook_to   = Square::fromFileAndRank(aside ? 3 : 5, from.rank());
+
+        new_pos.m_board[king_from]              = Place::empty();
+        new_pos.m_board[rook_from]              = Place::empty();
+        new_pos.m_board[king_to]                = Place{m_active_color, PieceType::king, king_id};
+        new_pos.m_board[rook_to]                = Place{m_active_color, PieceType::rook, rook_id};
+        new_pos.m_piece_list_sq[color][king_id] = king_to;
+        new_pos.m_piece_list_sq[color][rook_id] = rook_to;
+        new_pos.m_50mr++;
+        new_pos.m_rook_info[color].clear();
+        break;
+    }
+    case MoveFlags::en_passant : {
+        const Square victim_sq     = Square::fromFileAndRank(m_enpassant.file(), from.rank());
+        const Place  victim        = m_board[victim_sq];
+        new_pos.m_board[from]      = Place::empty();
+        new_pos.m_board[victim_sq] = Place::empty();
+        new_pos.m_board[to]        = src;
+        new_pos.m_piece_list_sq[color][src.id()]     = to;
+        new_pos.m_piece_list_sq[!color][victim.id()] = Square::invalid();
+        new_pos.m_piece_list[!color][victim.id()]    = PieceType::none;
+        new_pos.m_50mr                               = 0;
+        break;
+    }
+    case MoveFlags::promo_knight :
+    case MoveFlags::promo_bishop :
+    case MoveFlags::promo_rook :
+    case MoveFlags::promo_queen :
+        new_pos.m_board[from]                    = Place::empty();
+        new_pos.m_board[to]                      = Place{m_active_color, *m.promo(), src.id()};
+        new_pos.m_piece_list_sq[color][src.id()] = to;
+        new_pos.m_piece_list[color][src.id()]    = *m.promo();
+        new_pos.m_50mr                           = 0;
+        break;
+    case MoveFlags::promo_knight_capture :
+    case MoveFlags::promo_bishop_capture :
+    case MoveFlags::promo_rook_capture :
+    case MoveFlags::promo_queen_capture :
+        new_pos.m_board[from]                     = Place::empty();
+        new_pos.m_board[to]                       = Place{m_active_color, *m.promo(), src.id()};
+        new_pos.m_piece_list_sq[color][src.id()]  = to;
+        new_pos.m_piece_list[color][src.id()]     = *m.promo();
+        new_pos.m_piece_list_sq[!color][dst.id()] = Square::invalid();
+        new_pos.m_piece_list[!color][dst.id()]    = PieceType::none;
+        new_pos.m_50mr                            = 0;
+        check_dst_castling_rights();
+        break;
+    }
+
+    new_pos.m_active_color = invert(m_active_color);
+    new_pos.m_ply++;
+
+    // TODO: Do this incrementally
+    new_pos.m_attack_table = new_pos.calcAttacksSlow();
+
+    return new_pos;
+}
+
+const std::array<Wordboard, 2> Position::calcAttacksSlow() {
+    std::array<Wordboard, 2> result{};
+    for (usize i = 0; i < 64; i++)
+    {
+        const Square sq{static_cast<u8>(i)};
+        const auto [white, black] = calcAttacksSlow(sq);
+        result[0].mailbox[i]      = white;
+        result[1].mailbox[i]      = black;
+    }
+    return result;
+}
+
+const std::array<u16, 2> Position::calcAttacksSlow(Square sq) {
+    const auto [ray_coords, ray_valid] = geometry::superpieceRays(sq);
+    const v512 ray_places              = v512::permute8(ray_coords, m_board.toVec());
+
+    const u64 occupied = ray_places.nonzero8();
+    const u64 color    = ray_places.msb8();
+
+    const u64 visible = geometry::superpieceAttacks(occupied, ray_valid) & occupied;
+
+    const u64 attackers       = geometry::attackersFromRays(ray_places);
+    const u64 white_attackers = ~color & visible & attackers;
+    const u64 black_attackers = color & visible & attackers;
+
+    const int  white_attackers_count = std::popcount(white_attackers);
+    const int  black_attackers_count = std::popcount(black_attackers);
+    const v128 white_attackers_coord = v512::compress8(white_attackers, ray_coords).to128();
+    const v128 black_attackers_coord = v512::compress8(black_attackers, ray_coords).to128();
+    return {
+      findset8(white_attackers_coord, white_attackers_count, m_piece_list_sq[0].toVec()),
+      findset8(black_attackers_coord, black_attackers_count, m_piece_list_sq[1].toVec()),
+    };
+}
+
+std::optional<Position> Position::parse(std::string_view str) {
+    std::istringstream is{std::string{str}};
+
+    std::string board, color, castle, enpassant, irreversible_clock, ply;
+    is >> board >> color >> castle >> enpassant >> irreversible_clock >> ply;
+
+    return parse(board, color, castle, enpassant, irreversible_clock, ply);
+}
+
+std::optional<Position> Position::parse(std::string_view board,
+                                        std::string_view color,
+                                        std::string_view castle,
+                                        std::string_view enpassant,
+                                        std::string_view irreversible_clock,
+                                        std::string_view ply) {
+    Position result{};
+
+    // Parse board
+    {
+        int               place_index = 0;
+        usize             i           = 0;
+        std::array<u8, 2> id          = {1, 1};
+        for (; place_index < 64 && i < board.size(); i++)
+        {
+            const int    file = place_index % 8;
+            const int    rank = 7 - place_index / 8;
+            const Square sq   = Square::fromFileAndRank(file, rank);
+            const char   ch   = board[i];
+
+            const auto put_piece_raw = [&](Color color, PieceType ptype, u8 current_id) {
+                result.m_board.mailbox[sq.raw] = Place{color, ptype, PieceId{current_id}};
+                result.m_piece_list_sq[static_cast<usize>(color)].array[current_id] = sq;
+                result.m_piece_list[static_cast<usize>(color)].array[current_id]    = ptype;
+                place_index++;
+            };
+
+            const auto put_piece = [&](Color color, PieceType ptype) -> bool {
+                u8& current_id = id[static_cast<usize>(color)];
+                if (current_id >= 0x10)
+                    return false;
+                put_piece_raw(color, ptype, current_id);
+                current_id++;
+                return true;
+            };
+
+            switch (ch)
+            {
+            case '/' :
+                if (file != 0 || place_index == 0)
+                    return std::nullopt;
+                break;
+            case '1' :
+            case '2' :
+            case '3' :
+            case '4' :
+            case '5' :
+            case '6' :
+            case '7' :
+            case '8' :
+                place_index += ch - '0';
+                break;
+            case 'K' :
+                // TODO: Error if king already on board
+                put_piece_raw(Color::white, PieceType::king, 0);
+                break;
+            case 'Q' :
+                if (!put_piece(Color::white, PieceType::queen))
+                    return std::nullopt;
+                break;
+            case 'R' :
+                if (!put_piece(Color::white, PieceType::rook))
+                    return std::nullopt;
+                break;
+            case 'B' :
+                if (!put_piece(Color::white, PieceType::bishop))
+                    return std::nullopt;
+                break;
+            case 'N' :
+                if (!put_piece(Color::white, PieceType::knight))
+                    return std::nullopt;
+                break;
+            case 'P' :
+                if (!put_piece(Color::white, PieceType::pawn))
+                    return std::nullopt;
+                break;
+            case 'k' :
+                // TODO: Error if king already on board
+                put_piece_raw(Color::black, PieceType::king, 0);
+                break;
+            case 'q' :
+                if (!put_piece(Color::black, PieceType::queen))
+                    return std::nullopt;
+                break;
+            case 'r' :
+                if (!put_piece(Color::black, PieceType::rook))
+                    return std::nullopt;
+                break;
+            case 'b' :
+                if (!put_piece(Color::black, PieceType::bishop))
+                    return std::nullopt;
+                break;
+            case 'n' :
+                if (!put_piece(Color::black, PieceType::knight))
+                    return std::nullopt;
+                break;
+            case 'p' :
+                if (!put_piece(Color::black, PieceType::pawn))
+                    return std::nullopt;
+                break;
+            default :
+                return std::nullopt;
+            }
+        }
+        if (place_index != 64 || i != board.size())
+            return std::nullopt;
+    }
+
+    // Parse color
+    if (color.size() != 1)
+        return std::nullopt;
+    switch (color[0])
+    {
+    case 'b' :
+        result.m_active_color = Color::black;
+        break;
+    case 'w' :
+        result.m_active_color = Color::white;
+        break;
+    default :
+        return std::nullopt;
+    }
+
+    // Parse castling rights
+    // TODO: FRC, Error detection
+    if (castle != "-")
+    {
+        for (const char ch : castle)
+        {
+            switch (ch)
+            {
+            case 'K' :
+            case 'H' :
+                result.m_rook_info[0].hside = *Square::parse("h1");
+                break;
+            case 'Q' :
+            case 'A' :
+                result.m_rook_info[0].aside = *Square::parse("a1");
+                break;
+            case 'k' :
+            case 'h' :
+                result.m_rook_info[1].hside = *Square::parse("h8");
+                break;
+            case 'q' :
+            case 'a' :
+                result.m_rook_info[1].aside = *Square::parse("a8");
+                break;
+            default :
+                return std::nullopt;
+            }
+        }
+    }
+
+    // En passant
+    if (enpassant != "-")
+    {
+        const auto sq = Square::parse(enpassant);
+        if (!sq)
+            return std::nullopt;
+        result.m_enpassant = *sq;
+    }
+
+    // Parse 50mr clock
+    if (const int value = std::stoi(std::string{irreversible_clock}); value <= 100)
+    {
+        result.m_50mr = static_cast<u16>(value);
+    }
+    else
+    {
+        return std::nullopt;
+    }
+
+    // Parse game ply
+    if (const int value = std::stoi(std::string{ply}); value != 0 && value < 10000)
+    {
+        result.m_ply = static_cast<u16>((value - 1) * 2 + static_cast<int>(result.m_active_color));
+    }
+    else
+    {
+        return std::nullopt;
+    }
+
+    result.m_attack_table = result.calcAttacksSlow();
+
+    return result;
+}
+
+std::ostream& operator<<(std::ostream& os, const Position& position) {
+    int        blanks      = 0;
+    const auto emit_blanks = [&] {
+        if (blanks != 0)
+        {
+            os << blanks;
+            blanks = 0;
+        }
+    };
+
+    for (int rank = 7; rank >= 0; rank--)
+    {
+        for (int file = 0; file < 8; file++)
+        {
+            const Square sq = Square::fromFileAndRank(file, rank);
+            const Place  p  = position.m_board.mailbox[sq.raw];
+
+            if (p.isEmpty())
+            {
+                blanks++;
+            }
+            else
+            {
+                emit_blanks();
+                os << p.toChar();
+            }
+
+            if (file == 7)
+            {
+                emit_blanks();
+                if (rank != 0)
+                    os << '/';
+            }
+        }
+    }
+
+    os << ' ' << color_char(position.m_active_color) << ' ';
+
+    // TODO: FRC
+    const RookInfo white_rook_info = position.rookInfo(Color::white);
+    const RookInfo black_rook_info = position.rookInfo(Color::black);
+    if (white_rook_info.isClear() && black_rook_info.isClear())
+        os << '-';
+    if (white_rook_info.hside.isValid())
+        os << 'K';
+    if (white_rook_info.aside.isValid())
+        os << 'Q';
+    if (black_rook_info.hside.isValid())
+        os << 'k';
+    if (black_rook_info.aside.isValid())
+        os << 'q';
+
+    if (position.m_enpassant.isValid())
+        os << ' ' << position.m_enpassant << ' ';
+    else
+        os << " - ";
+
+    os << position.m_50mr << ' ' << (position.m_ply / 2 + 1);
+
+    return os;
+}
+
+}

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <array>
+#include <bit>
+#include <cassert>
+#include <iosfwd>
+
+#include "board.hpp"
+#include "move.hpp"
+#include "square.hpp"
+#include "util/types.hpp"
+#include "util/vec.hpp"
+
+namespace Clockwork {
+
+template<typename T>
+struct alignas(16) PieceList {
+    std::array<T, 16> array{};
+
+    constexpr T& operator[](PieceId id) { return array[id.raw]; }
+    constexpr T  operator[](PieceId id) const { return array[id.raw]; }
+
+    v128 toVec() const {
+        static_assert(sizeof(array) == sizeof(v128));
+        return v128::load(array.data());
+    }
+
+    u16 maskValid() const { return toVec().nonzero8(); }
+
+    u16 maskEq(PieceType ptype) const {
+        return v128::eq8(toVec(), v128::broadcast8(static_cast<u8>(ptype)));
+    }
+
+    constexpr bool operator==(const PieceList& other) const { return array == other.array; }
+};
+
+struct RookInfo {
+    Square aside = Square::invalid();
+    Square hside = Square::invalid();
+
+    constexpr void clear() {
+        aside = Square::invalid();
+        hside = Square::invalid();
+    }
+
+    constexpr void unset(Square sq) {
+        aside = aside == sq ? Square::invalid() : aside;
+        hside = hside == sq ? Square::invalid() : hside;
+    }
+
+    constexpr bool isClear() const { return !aside.isValid() && !hside.isValid(); }
+
+    constexpr bool operator==(const RookInfo&) const = default;
+};
+
+struct Position {
+   private:
+    std::array<Wordboard, 2>            m_attack_table{};
+    std::array<PieceList<Square>, 2>    m_piece_list_sq{};
+    std::array<PieceList<PieceType>, 2> m_piece_list{};
+    Byteboard                           m_board{};
+    u64                                 m_hash{};
+    u16                                 m_50mr{};
+    u16                                 m_ply{};
+    Color                               m_active_color{};
+    Square                              m_enpassant = Square::invalid();
+    std::array<RookInfo, 2>             m_rook_info;
+
+   public:
+    constexpr Position() = default;
+
+    const Byteboard& board() const { return m_board; }
+    const Wordboard& attackTable(Color color) const {
+        return m_attack_table[static_cast<usize>(color)];
+    }
+    const PieceList<PieceType>& pieceList(Color color) const {
+        return m_piece_list[static_cast<usize>(color)];
+    }
+    const PieceList<Square>& pieceListSq(Color color) const {
+        return m_piece_list_sq[static_cast<usize>(color)];
+    }
+    Color    activeColor() const { return m_active_color; }
+    Square   enPassant() const { return m_enpassant; }
+    RookInfo rookInfo(Color color) const { return m_rook_info[static_cast<usize>(color)]; }
+
+    Square kingSq(Color color) const { return pieceListSq(color)[PieceId{0}]; }
+
+    bool isValid() const {
+        return attackTable(m_active_color)[kingSq(invert(m_active_color))] == 0;
+    }
+
+    Position move(Move m) const;
+
+    const std::array<Wordboard, 2> calcAttacksSlow();
+    const std::array<u16, 2>       calcAttacksSlow(Square sq);
+
+    static std::optional<Position> parse(std::string_view str);
+    static std::optional<Position> parse(std::string_view board,
+                                         std::string_view color,
+                                         std::string_view castle,
+                                         std::string_view enpassant,
+                                         std::string_view irreversible_clock,
+                                         std::string_view ply);
+
+    bool                 operator==(const Position&) const = default;
+    friend std::ostream& operator<<(std::ostream& os, const Position& position);
+};
+
+}

--- a/src/square.hpp
+++ b/src/square.hpp
@@ -17,7 +17,6 @@ struct Square {
         return {0x80};
     }
 
-
     static constexpr Square from_file_and_rank(int file, int rank) {
         assert(file >= 0 && file < 8);
         assert(rank >= 0 && rank < 8);
@@ -29,26 +28,26 @@ struct Square {
             return std::nullopt;
         if (str[0] < 'a' or str[0] > 'h')
             return std::nullopt;
-        const int FILE = str[0] - 'a';
+        int file = str[0] - 'a';
         if (str[1] < '1' or str[1] > '8')
             return std::nullopt;
-        const int RANK = str[1] - '1';
-        return from_file_and_rank(FILE, RANK);
+        int rank = str[1] - '1';
+        return from_file_and_rank(file, rank);
     }
 
-    [[nodiscard]] constexpr usize file() const {
+    [[nodiscard]] constexpr int file() const {
         return raw % 8;
     }
 
-    [[nodiscard]] constexpr usize rank() const {
+    [[nodiscard]] constexpr int rank() const {
         return raw / 8;
     }
 
-    [[nodiscard]] constexpr bool isValid() const {
+    [[nodiscard]] constexpr bool is_valid() const {
         return (raw & 0x80) == 0;
     }
 
-    [[nodiscard]] constexpr u64 toBitboard() const {
+    [[nodiscard]] constexpr u64 to_bitboard() const {
         return static_cast<u64>(1) << raw;
     }
 
@@ -57,7 +56,7 @@ struct Square {
         return os << file << sq.rank() + 1;
     }
 
-    constexpr std::strong_ordering operator<=>(const Square&) const = default;
+    const std::strong_ordering operator<=>(const Square&) const = default;
 };
 
 }

--- a/src/square.hpp
+++ b/src/square.hpp
@@ -2,19 +2,21 @@
 
 #include "util/types.hpp"
 
-#include <string_view>
 #include <cassert>
-#include <ostream>
+#include <compare>
 #include <optional>
+#include <ostream>
+#include <string_view>
 
 namespace Clockwork {
 
 struct Square {
     u8 raw;
 
-    constexpr Square(u8 r) :
-        raw{r} {
+    static constexpr Square invalid() {
+        return {0x80};
     }
+
 
     static constexpr Square from_file_and_rank(int file, int rank) {
         assert(file >= 0 && file < 8);
@@ -42,10 +44,20 @@ struct Square {
         return raw / 8;
     }
 
+    [[nodiscard]] constexpr bool isValid() const {
+        return (raw & 0x80) == 0;
+    }
+
+    [[nodiscard]] constexpr u64 toBitboard() const {
+        return static_cast<u64>(1) << raw;
+    }
+
     friend std::ostream& operator<<(std::ostream& os, Square sq) {
         char file = static_cast<char>('a' + sq.file());
         return os << file << sq.rank() + 1;
     }
+
+    constexpr std::strong_ordering operator<=>(const Square&) const = default;
 };
 
 }

--- a/src/util/bit.hpp
+++ b/src/util/bit.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "util/types.hpp"
+
+namespace Clockwork {
+
+template<typename T>
+[[nodiscard]] constexpr T clear_lowest_bit(T x) {
+    return x & (x - 1);
+}
+
+}

--- a/src/util/static_vector.hpp
+++ b/src/util/static_vector.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <utility>
+#include <cassert>
+
+#include "util/types.hpp"
+
+namespace Clockwork {
+
+template<typename T, usize cap>
+class StaticVector {
+   public:
+    using value_type     = T;
+    using iterator       = T*;
+    using const_iterator = const T*;
+    using size_type      = usize;
+
+    constexpr StaticVector() = default;
+    ~StaticVector()          = default;
+
+    constexpr StaticVector(const StaticVector& other) :
+        len(other.len) {
+        std::copy(other.begin(), other.end(), begin());
+    }
+
+    constexpr StaticVector(StaticVector&& other) :
+        len(std::exchange(other.len, 0)) {
+        std::move(other.begin(), other.end(), begin());
+    }
+
+    constexpr StaticVector& operator=(const StaticVector& other) {
+        len = other.len;
+        std::copy(other.begin(), other.end(), begin());
+        return *this;
+    }
+
+    constexpr StaticVector& operator=(StaticVector&& other) {
+        len = std::exchange(other.len, 0);
+        std::move(other.begin(), other.end(), begin());
+        return *this;
+    }
+
+    constexpr iterator push_back(const T& value) {
+        assert(len < cap);
+        data[len] = value;
+        return &data[len++];
+    }
+
+    constexpr void append(StaticVector&& other) {
+        assert(len + other.len < cap);
+        std::move(other.begin(), other.end(), end());
+        len += std::exchange(other.len, 0);
+    }
+
+    constexpr void clear() { len = 0; }
+
+    constexpr usize size() const { return len; }
+    constexpr usize capacity() const { return cap; }
+    constexpr bool  empty() const { return len == 0; }
+
+    constexpr auto resize(usize new_size) -> void {
+        assert(new_size <= cap);
+        len = new_size;
+    }
+
+    constexpr T& operator[](usize index) {
+        assert(index < len);
+        return data[index];
+    }
+    constexpr const T& operator[](usize index) const {
+        assert(index < len);
+        return data[index];
+    }
+
+    constexpr iterator       begin() { return &data[0]; }
+    constexpr const_iterator begin() const { return &data[0]; }
+    constexpr const_iterator cbegin() const { return begin(); }
+
+    constexpr iterator       end() { return &data[len]; }
+    constexpr const_iterator end() const { return &data[len]; }
+    constexpr const_iterator cend() const { return end(); }
+
+   protected:
+    usize              len = 0;
+    std::array<T, cap> data;
+};
+
+}  // namespace Clockwork

--- a/src/util/static_vector.hpp
+++ b/src/util/static_vector.hpp
@@ -11,7 +11,7 @@ namespace Clockwork {
 
 template<typename T, usize cap>
 class StaticVector {
-   public:
+public:
     using value_type     = T;
     using iterator       = T*;
     using const_iterator = const T*;
@@ -54,11 +54,19 @@ class StaticVector {
         len += std::exchange(other.len, 0);
     }
 
-    constexpr void clear() { len = 0; }
+    constexpr void clear() {
+        len = 0;
+    }
 
-    constexpr usize size() const { return len; }
-    constexpr usize capacity() const { return cap; }
-    constexpr bool  empty() const { return len == 0; }
+    [[nodiscard]] constexpr usize size() const {
+        return len;
+    }
+    [[nodiscard]] constexpr usize capacity() const {
+        return cap;
+    }
+    [[nodiscard]] constexpr bool empty() const {
+        return len == 0;
+    }
 
     constexpr auto resize(usize new_size) -> void {
         assert(new_size <= cap);
@@ -74,15 +82,27 @@ class StaticVector {
         return data[index];
     }
 
-    constexpr iterator       begin() { return &data[0]; }
-    constexpr const_iterator begin() const { return &data[0]; }
-    constexpr const_iterator cbegin() const { return begin(); }
+    constexpr iterator begin() {
+        return &data[0];
+    }
+    constexpr const_iterator begin() const {
+        return &data[0];
+    }
+    constexpr const_iterator cbegin() const {
+        return begin();
+    }
 
-    constexpr iterator       end() { return &data[len]; }
-    constexpr const_iterator end() const { return &data[len]; }
-    constexpr const_iterator cend() const { return end(); }
+    constexpr iterator end() {
+        return &data[len];
+    }
+    constexpr const_iterator end() const {
+        return &data[len];
+    }
+    constexpr const_iterator cend() const {
+        return end();
+    }
 
-   protected:
+protected:
     usize              len = 0;
     std::array<T, cap> data;
 };

--- a/src/util/vec.hpp
+++ b/src/util/vec.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#if (__AVX512F__ && (__AVX512BW__ || __AVX512VNNI__))
+    #include "util/vec/avx512.hpp"
+#else
+    #include "util/vec/avx2.hpp"
+#endif

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -6,8 +6,12 @@
 
 namespace Clockwork {
 
-forceinline u32 concat32(u16 a, u16 b) { return static_cast<u32>(a) | (static_cast<u32>(b) << 16); }
-forceinline u64 concat64(u32 a, u32 b) { return static_cast<u64>(a) | (static_cast<u64>(b) << 32); }
+forceinline u32 concat32(u16 a, u16 b) {
+    return static_cast<u32>(a) | (static_cast<u32>(b) << 16);
+}
+forceinline u64 concat64(u32 a, u32 b) {
+    return static_cast<u64>(a) | (static_cast<u64>(b) << 32);
+}
 
 struct v128 {
     __m128i raw{};
@@ -21,17 +25,23 @@ struct v128 {
     forceinline constexpr v128(__m128i raw) :
         raw(raw){};
     forceinline explicit v128(std::array<u8, 16> src) :
-        raw(std::bit_cast<__m128i>(src)) {}
+        raw(std::bit_cast<__m128i>(src)) {
+    }
     forceinline explicit v128(std::array<u16, 8> src) :
-        raw(std::bit_cast<__m128i>(src)) {}
+        raw(std::bit_cast<__m128i>(src)) {
+    }
 
     static forceinline v128 load(const void* src) {
         return {_mm_loadu_si128(reinterpret_cast<const __m128i*>(src))};
     }
 
-    static forceinline v128 zero() { return {_mm_setzero_si128()}; }
+    static forceinline v128 zero() {
+        return {_mm_setzero_si128()};
+    }
 
-    static forceinline v128 broadcast8(u8 x) { return {_mm_set1_epi8(static_cast<i8>(x))}; }
+    static forceinline v128 broadcast8(u8 x) {
+        return {_mm_set1_epi8(static_cast<i8>(x))};
+    }
 
     static forceinline v128 blend8(v128 mask, v128 a, v128 b) {
         return {_mm_blendv_epi8(a.raw, b.raw, mask.raw)};
@@ -42,18 +52,20 @@ struct v128 {
     }
 
     static forceinline v128 permute8(v128 index, v128 a, v128 b, v128 c, v128 d) {
-        const v128 w = permute8(index, a);
-        const v128 x = permute8(index, b);
-        const v128 y = permute8(index, c);
-        const v128 z = permute8(index, d);
+        v128 w = permute8(index, a);
+        v128 x = permute8(index, b);
+        v128 y = permute8(index, c);
+        v128 z = permute8(index, d);
 
-        const v128 mask0 = shl16(index, 2);
-        const v128 mask1 = shl16(index, 3);
+        v128 mask0 = shl16(index, 2);
+        v128 mask1 = shl16(index, 3);
 
         return blend8(mask0, blend8(mask1, w, x), blend8(mask1, y, z));
     }
 
-    static forceinline v128 shl16(v128 a, int shift) { return {_mm_slli_epi16(a.raw, shift)}; }
+    static forceinline v128 shl16(v128 a, int shift) {
+        return {_mm_slli_epi16(a.raw, shift)};
+    }
 
     static forceinline u16 eq8(v128 a, v128 b) {
         return static_cast<u16>(_mm_movemask_epi8(_mm_cmpeq_epi8(a.raw, b.raw)));
@@ -63,10 +75,12 @@ struct v128 {
         return static_cast<u16>(~_mm_movemask_epi8(_mm_cmpeq_epi8(a.raw, b.raw)));
     }
 
-    forceinline u16 nonzero8() const { return neq8(*this, zero()); }
+    forceinline u16 nonzero8() const {
+        return neq8(*this, zero());
+    }
 
     forceinline bool operator==(const v128& other) const {
-        const __m128i t = _mm_xor_si128(raw, other.raw);
+        __m128i t = _mm_xor_si128(raw, other.raw);
         return _mm_testz_si128(t, t);
     }
 };
@@ -84,22 +98,36 @@ struct v256 {
     forceinline constexpr v256(__m256i raw) :
         raw(raw){};
     forceinline explicit v256(std::array<u8, 32> src) :
-        raw(std::bit_cast<__m256i>(src)) {}
+        raw(std::bit_cast<__m256i>(src)) {
+    }
     forceinline explicit v256(std::array<u16, 16> src) :
-        raw(std::bit_cast<__m256i>(src)) {}
+        raw(std::bit_cast<__m256i>(src)) {
+    }
     forceinline explicit v256(v128 a, v128 b) :
         raw(std::bit_cast<__m256i>(std::array<v128, 2>{a, b})){};
 
-    static forceinline v256 zero() { return {_mm256_setzero_si256()}; }
+    static forceinline v256 zero() {
+        return {_mm256_setzero_si256()};
+    }
 
-    static forceinline v256 broadcast8(u8 x) { return {_mm256_set1_epi8(static_cast<i8>(x))}; }
-    static forceinline v256 broadcast64(u64 x) { return {_mm256_set1_epi64x(static_cast<i64>(x))}; }
+    static forceinline v256 broadcast8(u8 x) {
+        return {_mm256_set1_epi8(static_cast<i8>(x))};
+    }
+    static forceinline v256 broadcast64(u64 x) {
+        return {_mm256_set1_epi64x(static_cast<i64>(x))};
+    }
 
-    static forceinline v256 from128(v128 a) { return {_mm256_castsi128_si256(a.raw)}; }
+    static forceinline v256 from128(v128 a) {
+        return {_mm256_castsi128_si256(a.raw)};
+    }
 
-    forceinline v128 to128() const { return {_mm256_castsi256_si128(raw)}; }
+    forceinline v128 to128() const {
+        return {_mm256_castsi256_si128(raw)};
+    }
 
-    static forceinline v256 add8(v256 a, v256 b) { return {_mm256_add_epi8(a.raw, b.raw)}; }
+    static forceinline v256 add8(v256 a, v256 b) {
+        return {_mm256_add_epi8(a.raw, b.raw)};
+    }
 
     static forceinline v256 permute8(v256 index, v256 a, v256 b) {
         return v256{v128::permute8(index.extract128<0>(), a.extract128<0>(), a.extract128<1>(),
@@ -108,7 +136,9 @@ struct v256 {
                                    b.extract128<0>(), b.extract128<1>())};
     }
 
-    static forceinline v256 shr16(v256 a, int shift) { return {_mm256_srli_epi16(a.raw, shift)}; }
+    static forceinline v256 shr16(v256 a, int shift) {
+        return {_mm256_srli_epi16(a.raw, shift)};
+    }
 
     static forceinline u32 eq8(v256 a, v256 b) {
         return static_cast<u32>(_mm256_movemask_epi8(_mm256_cmpeq_epi8(a.raw, b.raw)));
@@ -127,13 +157,19 @@ struct v256 {
     forceinline v128 extract128() const {
         return {_mm256_extracti128_si256(raw, offset)};
     }
-    forceinline u32 msb8() const { return static_cast<u32>(_mm256_movemask_epi8(raw)); }
+    forceinline u32 msb8() const {
+        return static_cast<u32>(_mm256_movemask_epi8(raw));
+    }
 
-    friend forceinline v256 operator&(v256 a, v256 b) { return {_mm256_and_si256(a.raw, b.raw)}; }
-    friend forceinline v256 operator|(v256 a, v256 b) { return {_mm256_or_si256(a.raw, b.raw)}; }
+    friend forceinline v256 operator&(v256 a, v256 b) {
+        return {_mm256_and_si256(a.raw, b.raw)};
+    }
+    friend forceinline v256 operator|(v256 a, v256 b) {
+        return {_mm256_or_si256(a.raw, b.raw)};
+    }
 
     forceinline bool operator==(const v256& other) const {
-        const __m256i t = _mm256_xor_si256(raw, other.raw);
+        __m256i t = _mm256_xor_si256(raw, other.raw);
         return _mm256_testz_si256(t, t);
     }
 };
@@ -151,11 +187,15 @@ struct v512 {
     forceinline constexpr explicit v512(v256 a, v256 b) :
         raw({a, b}){};
     forceinline explicit v512(std::array<u8, 64> src) :
-        raw(std::bit_cast<std::array<v256, 2>>(src)) {}
+        raw(std::bit_cast<std::array<v256, 2>>(src)) {
+    }
     forceinline explicit v512(std::array<u16, 32> src) :
-        raw(std::bit_cast<std::array<v256, 2>>(src)) {}
+        raw(std::bit_cast<std::array<v256, 2>>(src)) {
+    }
 
-    static forceinline v512 zero() { return v512{v256::zero(), v256::zero()}; }
+    static forceinline v512 zero() {
+        return v512{v256::zero(), v256::zero()};
+    }
 
     static forceinline v512 broadcast8(u8 x) {
         return v512{v256::broadcast8(x), v256::broadcast8(x)};
@@ -164,9 +204,13 @@ struct v512 {
         return v512{v256::broadcast64(x), v256::broadcast64(x)};
     }
 
-    static forceinline v512 from128(v128 a) { return v512{v256::from128(a), v256::zero()}; }
+    static forceinline v512 from128(v128 a) {
+        return v512{v256::from128(a), v256::zero()};
+    }
 
-    forceinline v128 to128() const { return raw[0].to128(); }
+    forceinline v128 to128() const {
+        return raw[0].to128();
+    }
 
     static forceinline v512 add8(v512 a, v512 b) {
         return v512{v256::add8(a.raw[0], b.raw[0]), v256::add8(a.raw[1], b.raw[1])};
@@ -175,7 +219,7 @@ struct v512 {
     static forceinline v512 compress8(u64 m, v512 a) {
         // TODO: Slow
         std::array<u8, 64> result{};
-        const auto         in = std::bit_cast<std::array<u8, 64>>(a);
+        auto               in = std::bit_cast<std::array<u8, 64>>(a);
         for (int i = 0; m != 0; i++, m &= m - 1)
             result[i] = in[static_cast<usize>(std::countr_zero(m))];
         return std::bit_cast<v512>(result);
@@ -202,12 +246,22 @@ struct v512 {
         return concat32(v256::neq16(a.raw[0], b.raw[0]), v256::neq16(a.raw[1], b.raw[1]));
     }
 
-    static forceinline u64 testn8(v512 a, v512 b) { return (a & b).zero8(); }
+    static forceinline u64 testn8(v512 a, v512 b) {
+        return (a & b).zero8();
+    }
 
-    forceinline u64 msb8() const { return concat64(raw[0].msb8(), raw[1].msb8()); }
-    forceinline u64 zero8() const { return eq8(*this, zero()); }
-    forceinline u64 nonzero8() const { return neq8(*this, zero()); }
-    forceinline u32 nonzero16() const { return neq16(*this, zero()); }
+    forceinline u64 msb8() const {
+        return concat64(raw[0].msb8(), raw[1].msb8());
+    }
+    forceinline u64 zero8() const {
+        return eq8(*this, zero());
+    }
+    forceinline u64 nonzero8() const {
+        return neq8(*this, zero());
+    }
+    forceinline u32 nonzero16() const {
+        return neq16(*this, zero());
+    }
 
     friend forceinline v512 operator&(v512 a, v512 b) {
         return v512{a.raw[0] & b.raw[0], a.raw[1] & b.raw[1]};
@@ -217,7 +271,9 @@ struct v512 {
         return v512{a.raw[0] | b.raw[0], a.raw[1] | b.raw[1]};
     }
 
-    forceinline auto operator==(const v512& other) const -> bool { return raw == other.raw; }
+    forceinline auto operator==(const v512& other) const -> bool {
+        return raw == other.raw;
+    }
 };
 static_assert(sizeof(v512) == 64);
 

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -4,6 +4,8 @@
 #include <bit>
 #include <x86intrin.h>
 
+#include "util/bit.hpp"
+
 namespace Clockwork {
 
 forceinline u32 concat32(u16 a, u16 b) {
@@ -220,7 +222,7 @@ struct v512 {
         // TODO: Slow
         std::array<u8, 64> result{};
         auto               in = std::bit_cast<std::array<u8, 64>>(a);
-        for (int i = 0; m != 0; i++, m &= m - 1)
+        for (int i = 0; m != 0; i++, m = clear_lowest_bit(m))
             result[i] = in[static_cast<usize>(std::countr_zero(m))];
         return std::bit_cast<v512>(result);
     }

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#include <array>
+#include <bit>
+#include <x86intrin.h>
+
+namespace Clockwork {
+
+forceinline u32 concat32(u16 a, u16 b) { return static_cast<u32>(a) | (static_cast<u32>(b) << 16); }
+forceinline u64 concat64(u32 a, u32 b) { return static_cast<u64>(a) | (static_cast<u64>(b) << 32); }
+
+struct v128 {
+    __m128i raw{};
+
+    using Mask8  = u16;
+    using Mask16 = u8;
+    using Mask32 = u8;
+    using Mask64 = u8;
+
+    forceinline constexpr v128() = default;
+    forceinline constexpr v128(__m128i raw) :
+        raw(raw){};
+    forceinline explicit v128(std::array<u8, 16> src) :
+        raw(std::bit_cast<__m128i>(src)) {}
+    forceinline explicit v128(std::array<u16, 8> src) :
+        raw(std::bit_cast<__m128i>(src)) {}
+
+    static forceinline v128 load(const void* src) {
+        return {_mm_loadu_si128(reinterpret_cast<const __m128i*>(src))};
+    }
+
+    static forceinline v128 zero() { return {_mm_setzero_si128()}; }
+
+    static forceinline v128 broadcast8(u8 x) { return {_mm_set1_epi8(static_cast<i8>(x))}; }
+
+    static forceinline v128 blend8(v128 mask, v128 a, v128 b) {
+        return {_mm_blendv_epi8(a.raw, b.raw, mask.raw)};
+    }
+
+    static forceinline v128 permute8(v128 index, v128 a) {
+        return {_mm_shuffle_epi8(a.raw, index.raw)};
+    }
+
+    static forceinline v128 permute8(v128 index, v128 a, v128 b, v128 c, v128 d) {
+        const v128 w = permute8(index, a);
+        const v128 x = permute8(index, b);
+        const v128 y = permute8(index, c);
+        const v128 z = permute8(index, d);
+
+        const v128 mask0 = shl16(index, 2);
+        const v128 mask1 = shl16(index, 3);
+
+        return blend8(mask0, blend8(mask1, w, x), blend8(mask1, y, z));
+    }
+
+    static forceinline v128 shl16(v128 a, int shift) { return {_mm_slli_epi16(a.raw, shift)}; }
+
+    static forceinline u16 eq8(v128 a, v128 b) {
+        return static_cast<u16>(_mm_movemask_epi8(_mm_cmpeq_epi8(a.raw, b.raw)));
+    }
+
+    static forceinline u16 neq8(v128 a, v128 b) {
+        return static_cast<u16>(~_mm_movemask_epi8(_mm_cmpeq_epi8(a.raw, b.raw)));
+    }
+
+    forceinline u16 nonzero8() const { return neq8(*this, zero()); }
+
+    forceinline bool operator==(const v128& other) const {
+        const __m128i t = _mm_xor_si128(raw, other.raw);
+        return _mm_testz_si128(t, t);
+    }
+};
+static_assert(sizeof(v128) == 16);
+
+struct v256 {
+    __m256i raw{};
+
+    using Mask8  = u32;
+    using Mask16 = u16;
+    using Mask32 = u8;
+    using Mask64 = u8;
+
+    forceinline constexpr v256() = default;
+    forceinline constexpr v256(__m256i raw) :
+        raw(raw){};
+    forceinline explicit v256(std::array<u8, 32> src) :
+        raw(std::bit_cast<__m256i>(src)) {}
+    forceinline explicit v256(std::array<u16, 16> src) :
+        raw(std::bit_cast<__m256i>(src)) {}
+    forceinline explicit v256(v128 a, v128 b) :
+        raw(std::bit_cast<__m256i>(std::array<v128, 2>{a, b})){};
+
+    static forceinline v256 zero() { return {_mm256_setzero_si256()}; }
+
+    static forceinline v256 broadcast8(u8 x) { return {_mm256_set1_epi8(static_cast<i8>(x))}; }
+    static forceinline v256 broadcast64(u64 x) { return {_mm256_set1_epi64x(static_cast<i64>(x))}; }
+
+    static forceinline v256 from128(v128 a) { return {_mm256_castsi128_si256(a.raw)}; }
+
+    forceinline v128 to128() const { return {_mm256_castsi256_si128(raw)}; }
+
+    static forceinline v256 add8(v256 a, v256 b) { return {_mm256_add_epi8(a.raw, b.raw)}; }
+
+    static forceinline v256 permute8(v256 index, v256 a, v256 b) {
+        return v256{v128::permute8(index.extract128<0>(), a.extract128<0>(), a.extract128<1>(),
+                                   b.extract128<0>(), b.extract128<1>()),
+                    v128::permute8(index.extract128<1>(), a.extract128<0>(), a.extract128<1>(),
+                                   b.extract128<0>(), b.extract128<1>())};
+    }
+
+    static forceinline v256 shr16(v256 a, int shift) { return {_mm256_srli_epi16(a.raw, shift)}; }
+
+    static forceinline u32 eq8(v256 a, v256 b) {
+        return static_cast<u32>(_mm256_movemask_epi8(_mm256_cmpeq_epi8(a.raw, b.raw)));
+    }
+
+    static forceinline u32 neq8(v256 a, v256 b) {
+        return static_cast<u32>(~_mm256_movemask_epi8(_mm256_cmpeq_epi8(a.raw, b.raw)));
+    }
+
+    static forceinline u16 neq16(v256 a, v256 b) {
+        return static_cast<u16>(_pext_u32(
+          static_cast<u32>(~_mm256_movemask_epi8(_mm256_cmpeq_epi16(a.raw, b.raw))), 0xAAAAAAAA));
+    }
+
+    template<int offset>
+    forceinline v128 extract128() const {
+        return {_mm256_extracti128_si256(raw, offset)};
+    }
+    forceinline u32 msb8() const { return static_cast<u32>(_mm256_movemask_epi8(raw)); }
+
+    friend forceinline v256 operator&(v256 a, v256 b) { return {_mm256_and_si256(a.raw, b.raw)}; }
+    friend forceinline v256 operator|(v256 a, v256 b) { return {_mm256_or_si256(a.raw, b.raw)}; }
+
+    forceinline bool operator==(const v256& other) const {
+        const __m256i t = _mm256_xor_si256(raw, other.raw);
+        return _mm256_testz_si256(t, t);
+    }
+};
+static_assert(sizeof(v256) == 32);
+
+struct v512 {
+    std::array<v256, 2> raw{};
+
+    using Mask8  = u64;
+    using Mask16 = u32;
+    using Mask32 = u16;
+    using Mask64 = u8;
+
+    forceinline constexpr v512() = default;
+    forceinline constexpr explicit v512(v256 a, v256 b) :
+        raw({a, b}){};
+    forceinline explicit v512(std::array<u8, 64> src) :
+        raw(std::bit_cast<std::array<v256, 2>>(src)) {}
+    forceinline explicit v512(std::array<u16, 32> src) :
+        raw(std::bit_cast<std::array<v256, 2>>(src)) {}
+
+    static forceinline v512 zero() { return v512{v256::zero(), v256::zero()}; }
+
+    static forceinline v512 broadcast8(u8 x) {
+        return v512{v256::broadcast8(x), v256::broadcast8(x)};
+    }
+    static forceinline v512 broadcast64(u64 x) {
+        return v512{v256::broadcast64(x), v256::broadcast64(x)};
+    }
+
+    static forceinline v512 from128(v128 a) { return v512{v256::from128(a), v256::zero()}; }
+
+    forceinline v128 to128() const { return raw[0].to128(); }
+
+    static forceinline v512 add8(v512 a, v512 b) {
+        return v512{v256::add8(a.raw[0], b.raw[0]), v256::add8(a.raw[1], b.raw[1])};
+    }
+
+    static forceinline v512 compress8(u64 m, v512 a) {
+        // TODO: Slow
+        std::array<u8, 64> result{};
+        const auto         in = std::bit_cast<std::array<u8, 64>>(a);
+        for (int i = 0; m != 0; i++, m &= m - 1)
+            result[i] = in[static_cast<usize>(std::countr_zero(m))];
+        return std::bit_cast<v512>(result);
+    }
+
+    static forceinline v512 permute8(v512 index, v512 a) {
+        return v512{v256::permute8(index.raw[0], a.raw[0], a.raw[1]),
+                    v256::permute8(index.raw[1], a.raw[0], a.raw[1])};
+    }
+
+    static forceinline v512 shr16(v512 a, int shift) {
+        return v512{v256::shr16(a.raw[0], shift), v256::shr16(a.raw[1], shift)};
+    }
+
+    static forceinline u64 eq8(v512 a, v512 b) {
+        return concat64(v256::eq8(a.raw[0], b.raw[0]), v256::eq8(a.raw[1], b.raw[1]));
+    }
+
+    static forceinline u64 neq8(v512 a, v512 b) {
+        return concat64(v256::neq8(a.raw[0], b.raw[0]), v256::neq8(a.raw[1], b.raw[1]));
+    }
+
+    static forceinline u32 neq16(v512 a, v512 b) {
+        return concat32(v256::neq16(a.raw[0], b.raw[0]), v256::neq16(a.raw[1], b.raw[1]));
+    }
+
+    static forceinline u64 testn8(v512 a, v512 b) { return (a & b).zero8(); }
+
+    forceinline u64 msb8() const { return concat64(raw[0].msb8(), raw[1].msb8()); }
+    forceinline u64 zero8() const { return eq8(*this, zero()); }
+    forceinline u64 nonzero8() const { return neq8(*this, zero()); }
+    forceinline u32 nonzero16() const { return neq16(*this, zero()); }
+
+    friend forceinline v512 operator&(v512 a, v512 b) {
+        return v512{a.raw[0] & b.raw[0], a.raw[1] & b.raw[1]};
+    }
+
+    friend forceinline v512 operator|(v512 a, v512 b) {
+        return v512{a.raw[0] | b.raw[0], a.raw[1] | b.raw[1]};
+    }
+
+    forceinline auto operator==(const v512& other) const -> bool { return raw == other.raw; }
+};
+static_assert(sizeof(v512) == 64);
+
+forceinline u16 findset8(v128 haystack, int haystack_len, v128 needles) {
+    return static_cast<u16>(
+      _mm_extract_epi16(_mm_cmpestrm(haystack.raw, haystack_len, needles.raw, 16, 0), 0));
+}
+
+}

--- a/src/util/vec/avx512.hpp
+++ b/src/util/vec/avx512.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+// TODO: Actually implement AVX512 version
+#include "avx2.hpp"

--- a/tests/test_perft.cpp
+++ b/tests/test_perft.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <sstream>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+#include <iomanip>
+
+#include "position.hpp"
+#include "perft.hpp"
+
+using namespace Clockwork;
+
+auto main() -> int {
+    const std::vector<std::tuple<std::string_view, std::vector<u64>>> cases{{
+      {"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+       {{1, 48, 2039, 97862, 4085603}}},
+      {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+       {{1, 20, 400, 8902, 197281, 4865609}}},
+    }};
+
+    for (auto [fen, results] : cases)
+    {
+        const Position position = *Position::parse(fen);
+        std::cout << fen << ":" << std::endl;
+
+        for (usize depth = 0; depth < results.size(); depth++)
+        {
+            const u64 value = perft(position, depth);
+
+            std::cout << depth << ":" << value << std::endl;
+
+            if (value != results[depth])
+            {
+                splitPerft(position, depth);
+                std::exit(1);
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tests/test_perft.cpp
+++ b/tests/test_perft.cpp
@@ -12,27 +12,24 @@
 using namespace Clockwork;
 
 auto main() -> int {
-    const std::vector<std::tuple<std::string_view, std::vector<u64>>> cases{{
+    std::vector<std::tuple<std::string_view, std::vector<u64>>> cases{{
       {"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
        {{1, 48, 2039, 97862, 4085603}}},
       {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
        {{1, 20, 400, 8902, 197281, 4865609}}},
     }};
 
-    for (auto [fen, results] : cases)
-    {
-        const Position position = *Position::parse(fen);
+    for (auto [fen, results] : cases) {
+        Position position = *Position::parse(fen);
         std::cout << fen << ":" << std::endl;
 
-        for (usize depth = 0; depth < results.size(); depth++)
-        {
+        for (usize depth = 0; depth < results.size(); depth++) {
             const u64 value = perft(position, depth);
 
             std::cout << depth << ":" << value << std::endl;
 
-            if (value != results[depth])
-            {
-                splitPerft(position, depth);
+            if (value != results[depth]) {
+                split_perft(position, depth);
                 std::exit(1);
             }
         }

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <sstream>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+#include "position.hpp"
+
+#define REQUIRE(x) \
+    if (!(x)) \
+        std::exit(1);
+
+using namespace Clockwork;
+
+void roundtripClassical() {
+    const std::vector<std::string_view> cases{{
+      "7r/3r1p1p/6p1/1p6/2B5/5PP1/1Q5P/1K1k4 b - - 0 38",
+      "r3k2r/pp1bnpbp/1q3np1/3p4/3N1P2/1PP1Q2P/P1B3P1/RNB1K2R b KQkq - 5 15",
+      "8/5p2/1kn1r1n1/1p1pP3/6K1/8/4R3/5R2 b - - 9 60",
+      "r4rk1/1Bp1qppp/2np1n2/1pb1p1B1/4P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - b6 1 11",
+    }};
+
+    for (std::string_view fen : cases)
+    {
+        const Position position = *Position::parse(fen);
+
+        std::ostringstream os;
+        os << position;
+
+        std::cout << fen << std::endl;
+        std::cout << position << std::endl;
+
+        REQUIRE(fen == os.str());
+    }
+}
+
+auto main() -> int {
+    roundtripClassical();
+    return 0;
+}

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -12,16 +12,15 @@
 
 using namespace Clockwork;
 
-void roundtripClassical() {
-    const std::vector<std::string_view> cases{{
+void roundtrip_classical_fens() {
+    std::vector<std::string_view> cases{{
       "7r/3r1p1p/6p1/1p6/2B5/5PP1/1Q5P/1K1k4 b - - 0 38",
       "r3k2r/pp1bnpbp/1q3np1/3p4/3N1P2/1PP1Q2P/P1B3P1/RNB1K2R b KQkq - 5 15",
       "8/5p2/1kn1r1n1/1p1pP3/6K1/8/4R3/5R2 b - - 9 60",
       "r4rk1/1Bp1qppp/2np1n2/1pb1p1B1/4P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - b6 1 11",
     }};
 
-    for (std::string_view fen : cases)
-    {
+    for (std::string_view fen : cases) {
         const Position position = *Position::parse(fen);
 
         std::ostringstream os;
@@ -35,6 +34,6 @@ void roundtripClassical() {
 }
 
 auto main() -> int {
-    roundtripClassical();
+    roundtrip_classical_fens();
     return 0;
 }


### PR DESCRIPTION
With movegen and perft.
Note this is slow because it's non-incremental (doing 16x more vector permutations than required).

Incremental version comes next.

We also have a testing infrastructure that uses ctest.

A simple way to run tests is:
```
mkdir build
cd build
cmake ..
make test
```