### PR TITLE
fix(prerelease): no x86-64-v1 or x86-64-v2 for now

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -92,8 +92,6 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - x86-64
-          - x86-64-v2
           - x86-64-v3
           - x86-64-v4
     runs-on: ubuntu-latest


### PR DESCRIPTION
to add back in the future when pre-avx2 support is added