### PR TITLE
permute double-pumping optimizations

### DIFF
--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -78,8 +78,8 @@ inline u64 attackers_from_rays(v512 ray_places) {
       HORSE, BPAWN_NEAR, DIAG, DIAG, DIAG, DIAG, DIAG, DIAG,  // NW
     }};
 
-    v512 bit_rays = v512::permute8(v512::shr16(ray_places, 4) & v512::broadcast8(0x0F),
-                                   v512::from128(PTYPE_TO_BITS));
+    v512 bit_rays =
+      v512::permute8(v512::shr16(ray_places, 4) & v512::broadcast8(0x0F), PTYPE_TO_BITS);
     return (bit_rays & ATTACKER_MASK).nonzero8();
 }
 

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -122,6 +122,13 @@ struct v256 {
         return {_mm256_broadcastsi128_si256(x.raw)};
     }
 
+    [[nodiscard]] forceinline v256 broadcast128lo() const {
+        return {_mm256_permute2x128_si256(raw, raw, 0b00000000)};
+    }
+    [[nodiscard]] forceinline v256 broadcast128hi() const {
+        return {_mm256_permute2x128_si256(raw, raw, 0b00010001)};
+    }
+
     static forceinline v256 from128(v128 a) {
         return {_mm256_castsi128_si256(a.raw)};
     }
@@ -134,15 +141,28 @@ struct v256 {
         return {_mm256_add_epi8(a.raw, b.raw)};
     }
 
+    static forceinline v256 blend8(v256 mask, v256 a, v256 b) {
+        return {_mm256_blendv_epi8(a.raw, b.raw, mask.raw)};
+    }
+
     static forceinline v256 permute8(v256 index, v128 a) {
         return {_mm256_shuffle_epi8(v256::broadcast128(a).raw, index.raw)};
     }
 
     static forceinline v256 permute8(v256 index, v256 a, v256 b) {
-        return v256{v128::permute8(index.extract128<0>(), a.extract128<0>(), a.extract128<1>(),
-                                   b.extract128<0>(), b.extract128<1>()),
-                    v128::permute8(index.extract128<1>(), a.extract128<0>(), a.extract128<1>(),
-                                   b.extract128<0>(), b.extract128<1>())};
+        v256 mask0 = shl16(index, 2);
+        v256 mask1 = shl16(index, 3);
+
+        v256 x = blend8(mask1, _mm256_shuffle_epi8(a.broadcast128lo().raw, index.raw),
+                        _mm256_shuffle_epi8(a.broadcast128hi().raw, index.raw));
+        v256 y = blend8(mask1, _mm256_shuffle_epi8(b.broadcast128lo().raw, index.raw),
+                        _mm256_shuffle_epi8(b.broadcast128hi().raw, index.raw));
+
+        return blend8(mask0, x, y);
+    }
+
+    static forceinline v256 shl16(v256 a, int shift) {
+        return {_mm256_slli_epi16(a.raw, shift)};
     }
 
     static forceinline v256 shr16(v256 a, int shift) {

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -118,6 +118,9 @@ struct v256 {
     static forceinline v256 broadcast64(u64 x) {
         return {_mm256_set1_epi64x(static_cast<i64>(x))};
     }
+    static forceinline v256 broadcast128(v128 x) {
+        return {_mm256_broadcastsi128_si256(x.raw)};
+    }
 
     static forceinline v256 from128(v128 a) {
         return {_mm256_castsi128_si256(a.raw)};
@@ -129,6 +132,10 @@ struct v256 {
 
     static forceinline v256 add8(v256 a, v256 b) {
         return {_mm256_add_epi8(a.raw, b.raw)};
+    }
+
+    static forceinline v256 permute8(v256 index, v128 a) {
+        return {_mm256_shuffle_epi8(v256::broadcast128(a).raw, index.raw)};
     }
 
     static forceinline v256 permute8(v256 index, v256 a, v256 b) {
@@ -230,6 +237,10 @@ struct v512 {
     static forceinline v512 permute8(v512 index, v512 a) {
         return v512{v256::permute8(index.raw[0], a.raw[0], a.raw[1]),
                     v256::permute8(index.raw[1], a.raw[0], a.raw[1])};
+    }
+
+    static forceinline v512 permute8(v512 index, v128 a) {
+        return v512{v256::permute8(index.raw[0], a), v256::permute8(index.raw[1], a)};
     }
 
     static forceinline v512 shr16(v512 a, int shift) {


### PR DESCRIPTION
Easy 2x perft speedup
25.49 sec -> 11.19 sec