### PR TITLE
Fix some style issues

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -11,8 +11,8 @@ std::ostream& operator<<(std::ostream& os, const Wordboard& at) {
     std::ios state{nullptr};
     state.copyfmt(os);
 
-    for (int rank = 7; rank >= 0; rank--) {
-        for (int file = 0; file < 8; file++) {
+    for (i32 rank = 7; rank >= 0; rank--) {
+        for (i32 file = 0; file < 8; file++) {
             Square sq    = Square::from_file_and_rank(file, rank);
             u16    value = at.read(sq);
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -39,7 +39,7 @@ struct Place {
 
     constexpr Place(Color color, PieceType pt, PieceId id) {
         raw =
-          static_cast<u8>((static_cast<int>(color) << 4) | (static_cast<int>(pt) << 5) | id.raw);
+          static_cast<u8>((static_cast<i32>(color) << 4) | (static_cast<i32>(pt) << 5) | id.raw);
     }
 
     [[nodiscard]] constexpr bool is_empty() const {

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -20,7 +20,7 @@ constexpr char color_char(Color color) {
 }
 
 constexpr Color invert(Color color) {
-    return static_cast<Color>(static_cast<int>(color) ^ 1);
+    return static_cast<Color>(static_cast<i32>(color) ^ 1);
 }
 
 enum class PieceType : u8 {

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -57,11 +57,11 @@ const std::array<v512, 64> SUPERPIECE_INVERSE_RAYS_AVX2_TABLE = []() {
 
 const std::array<v512, 64> PIECE_MOVES_AVX2_TABLE = []() {
     // clang-format off
-    constexpr u8 K = 1 << static_cast<int>(PieceType::King);
-    constexpr u8 Q = 1 << static_cast<int>(PieceType::Queen);
-    constexpr u8 B = 1 << static_cast<int>(PieceType::Bishop);
-    constexpr u8 R = 1 << static_cast<int>(PieceType::Rook);
-    constexpr u8 HORS = 1 << static_cast<int>(PieceType::Knight);
+    constexpr u8 K = 1 << static_cast<i32>(PieceType::King);
+    constexpr u8 Q = 1 << static_cast<i32>(PieceType::Queen);
+    constexpr u8 B = 1 << static_cast<i32>(PieceType::Bishop);
+    constexpr u8 R = 1 << static_cast<i32>(PieceType::Rook);
+    constexpr u8 HORS = 1 << static_cast<i32>(PieceType::Knight);
     constexpr u8 ORTH = Q | R;
     constexpr u8 DIAG = Q | B;
     constexpr u8 OADJ = ORTH | K;

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -126,7 +126,7 @@ extern const std::array<v512, 64> PIECE_MOVES_AVX2_TABLE;
 
 inline v512 piece_moves_avx2(bool color, PieceType ptype, Square sq) {
     assert(ptype != PieceType::None);
-    int  index = ptype == PieceType::Pawn ? color : static_cast<int>(ptype);
+    i32  index = ptype == PieceType::Pawn ? color : static_cast<i32>(ptype);
     v512 bit   = v512::broadcast8(static_cast<u8>(1 << index));
     v512 table = PIECE_MOVES_AVX2_TABLE[sq.raw];
     return v512::eq8_vm(table & bit, bit);

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -14,13 +14,13 @@ namespace Clockwork::geometry {
 
 namespace internal {
 // 00rrrfff → 0rrr0fff
-forceinline constexpr auto expand_sq(Square sq) -> u8 {
+forceinline constexpr u8 expand_sq(Square sq) {
     return sq.raw + (sq.raw & 0b111000);
 }
 
 // 0rrr0fff → 00rrrfff
 template<typename V>
-forceinline auto compress_coords(V list) -> std::tuple<V, V> {
+forceinline std::tuple<V, V> compress_coords(V list) {
     V valid      = V::eq8_vm(list & V::broadcast8(0x88), V::zero());
     V compressed = (list & V::broadcast8(0x07)) | (V::shr16(list, 1) & V::broadcast8(0x38));
     return {compressed, valid};

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -11,7 +11,7 @@
 
 namespace Clockwork {
 
-static std::tuple<u64, u64, u64, int, int> valid_pawns(Color color, u64 bb, u64 empty, u64 dests) {
+static std::tuple<u64, u64, u64, i32, i32> valid_pawns(Color color, u64 bb, u64 empty, u64 dests) {
     switch (color) {
     case Color::White: {
         u64 single = bb & ((empty & dests) >> 8);
@@ -65,7 +65,7 @@ void MoveGen::generate_moves(MoveList& moves) {
     // Castling
     // TODO: FRC
     {
-        int      color_shift = active_color == Color::White ? 0 : 56;
+        i32      color_shift = active_color == Color::White ? 0 : 56;
         Square   king_sq     = m_position.king_sq(active_color);
         RookInfo rook_info   = m_position.rook_info(active_color);
         if (rook_info.aside.is_valid()) {
@@ -125,7 +125,7 @@ void MoveGen::write(
     }
 }
 
-void MoveGen::write_pawn(MoveList& moves, u64 bb, int shift, MoveFlags mf) {
+void MoveGen::write_pawn(MoveList& moves, u64 bb, i32 shift, MoveFlags mf) {
     for (; bb != 0; bb = clear_lowest_bit(bb)) {
         Square src{static_cast<u8>(std::countr_zero(bb))};
         Square dest{static_cast<u8>(src.raw + shift)};

--- a/src/movegen.hpp
+++ b/src/movegen.hpp
@@ -21,7 +21,7 @@ public:
 private:
     void write(MoveList& moves, Square sq, u16 piecemask, MoveFlags mf);
     void write(MoveList& moves, const std::array<u16, 64>& at, u64 bb, u16 piecemask, MoveFlags mf);
-    void write_pawn(MoveList& moves, u64 bb, int shift, MoveFlags mf);
+    void write_pawn(MoveList& moves, u64 bb, i32 shift, MoveFlags mf);
 
     Color           m_active_color;
     const Position& m_position;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -279,8 +279,8 @@ const std::array<u16, 2> Position::calc_attacks_slow(Square sq) {
     u64  white_attackers   = ~color & visible_attackers;
     u64  black_attackers   = color & visible_attackers;
 
-    int  white_attackers_count = std::popcount(white_attackers);
-    int  black_attackers_count = std::popcount(black_attackers);
+    i32  white_attackers_count = std::popcount(white_attackers);
+    i32  black_attackers_count = std::popcount(black_attackers);
     v128 white_attackers_coord = v512::compress8(white_attackers, ray_coords).to128();
     v128 black_attackers_coord = v512::compress8(black_attackers, ray_coords).to128();
     return {
@@ -308,12 +308,12 @@ std::optional<Position> Position::parse(std::string_view board,
 
     // Parse board
     {
-        int               place_index = 0;
+        i32               place_index = 0;
         usize             i           = 0;
         std::array<u8, 2> id          = {1, 1};
         for (; place_index < 64 && i < board.size(); i++) {
-            int    file = place_index % 8;
-            int    rank = 7 - place_index / 8;
+            i32    file = place_index % 8;
+            i32    rank = 7 - place_index / 8;
             Square sq   = Square::from_file_and_rank(file, rank);
             char   ch   = board[i];
 
@@ -469,15 +469,15 @@ std::optional<Position> Position::parse(std::string_view board,
     }
 
     // Parse 50mr clock
-    if (int value = std::stoi(std::string{irreversible_clock}); value <= 100) {
+    if (i32 value = std::stoi(std::string{irreversible_clock}); value <= 100) {
         result.m_50mr = static_cast<u16>(value);
     } else {
         return std::nullopt;
     }
 
     // Parse game ply
-    if (int value = std::stoi(std::string{ply}); value != 0 && value < 10000) {
-        result.m_ply = static_cast<u16>((value - 1) * 2 + static_cast<int>(result.m_active_color));
+    if (i32 value = std::stoi(std::string{ply}); value != 0 && value < 10000) {
+        result.m_ply = static_cast<u16>((value - 1) * 2 + static_cast<i32>(result.m_active_color));
     } else {
         return std::nullopt;
     }
@@ -488,7 +488,7 @@ std::optional<Position> Position::parse(std::string_view board,
 }
 
 std::ostream& operator<<(std::ostream& os, const Position& position) {
-    int  blanks      = 0;
+    i32  blanks      = 0;
     auto emit_blanks = [&] {
         if (blanks != 0) {
             os << blanks;
@@ -496,8 +496,8 @@ std::ostream& operator<<(std::ostream& os, const Position& position) {
         }
     };
 
-    for (int rank = 7; rank >= 0; rank--) {
-        for (int file = 0; file < 8; file++) {
+    for (i32 rank = 7; rank >= 0; rank--) {
+        for (i32 file = 0; file < 8; file++) {
             Square sq = Square::from_file_and_rank(file, rank);
             Place  p  = position.m_board.mailbox[sq.raw];
 

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -64,28 +64,6 @@ struct RookInfo {
 };
 
 struct Position {
-private:
-    std::array<Wordboard, 2>            m_attack_table{};
-    std::array<PieceList<Square>, 2>    m_piece_list_sq{};
-    std::array<PieceList<PieceType>, 2> m_piece_list{};
-    Byteboard                           m_board{};
-    u64                                 m_hash{};
-    u16                                 m_50mr{};
-    u16                                 m_ply{};
-    Color                               m_active_color{};
-    Square                              m_enpassant = Square::invalid();
-    std::array<RookInfo, 2>             m_rook_info;
-
-    void incrementally_remove_piece(bool color, PieceId id, Square sq);
-    void incrementally_add_piece(bool color, Place p, Square sq);
-    void
-    incrementally_mutate_piece(bool old_color, PieceId old_id, Square sq, bool new_color, Place p);
-
-    void remove_attacks(bool color, PieceId id);
-    v512 toggle_rays(Square sq);
-    void add_attacks(bool color, PieceId id, Square sq, PieceType ptype);
-    void add_attacks(bool color, PieceId id, Square sq, PieceType ptype, v512 mask);
-
 public:
     constexpr Position() = default;
 
@@ -134,6 +112,28 @@ public:
 
     bool                 operator==(const Position&) const = default;
     friend std::ostream& operator<<(std::ostream& os, const Position& position);
+
+private:
+    std::array<Wordboard, 2>            m_attack_table{};
+    std::array<PieceList<Square>, 2>    m_piece_list_sq{};
+    std::array<PieceList<PieceType>, 2> m_piece_list{};
+    Byteboard                           m_board{};
+    u64                                 m_hash{};
+    u16                                 m_50mr{};
+    u16                                 m_ply{};
+    Color                               m_active_color{};
+    Square                              m_enpassant = Square::invalid();
+    std::array<RookInfo, 2>             m_rook_info;
+
+    void incrementally_remove_piece(bool color, PieceId id, Square sq);
+    void incrementally_add_piece(bool color, Place p, Square sq);
+    void
+    incrementally_mutate_piece(bool old_color, PieceId old_id, Square sq, bool new_color, Place p);
+
+    void remove_attacks(bool color, PieceId id);
+    v512 toggle_rays(Square sq);
+    void add_attacks(bool color, PieceId id, Square sq, PieceType ptype);
+    void add_attacks(bool color, PieceId id, Square sq, PieceType ptype, v512 mask);
 };
 
 }

--- a/src/square.hpp
+++ b/src/square.hpp
@@ -17,7 +17,7 @@ struct Square {
         return {0x80};
     }
 
-    static constexpr Square from_file_and_rank(int file, int rank) {
+    static constexpr Square from_file_and_rank(i32 file, i32 rank) {
         assert(file >= 0 && file < 8);
         assert(rank >= 0 && rank < 8);
         return Square{static_cast<u8>(rank * 8 + file)};
@@ -30,19 +30,19 @@ struct Square {
         if (str[0] < 'a' or str[0] > 'h') {
             return std::nullopt;
         }
-        int file = str[0] - 'a';
+        i32 file = str[0] - 'a';
         if (str[1] < '1' or str[1] > '8') {
             return std::nullopt;
         }
-        int rank = str[1] - '1';
+        i32 rank = str[1] - '1';
         return from_file_and_rank(file, rank);
     }
 
-    [[nodiscard]] constexpr int file() const {
+    [[nodiscard]] constexpr i32 file() const {
         return raw % 8;
     }
 
-    [[nodiscard]] constexpr int rank() const {
+    [[nodiscard]] constexpr i32 rank() const {
         return raw / 8;
     }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,8 +28,8 @@ void UCIHandler::loop() {
     }
 }
 
-void UCIHandler::handle_command_line(int argc, char* argv[]) {
-    for (int i = 1; i < argc; ++i) {
+void UCIHandler::handle_command_line(i32 argc, char* argv[]) {
+    for (i32 i = 1; i < argc; ++i) {
         execute_command(argv[i]);
     }
 }
@@ -137,7 +137,7 @@ void UCIHandler::handle_attacks(std::istringstream&) {
 
 void UCIHandler::handle_perft(std::istringstream& is) {
     std::string token;
-    int         depth = 1;
+    i32         depth = 1;
 
     if (is >> token) {
         depth = std::stoi(token);

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -8,12 +8,12 @@
 namespace Clockwork::UCI {
 
 struct SearchSettings {
-    int depth     = 0;
-    int w_time    = 0;
-    int b_time    = 0;
-    int w_inc     = 0;
-    int b_inc     = 0;
-    int move_time = 0;
+    i32 depth     = 0;
+    i32 w_time    = 0;
+    i32 b_time    = 0;
+    i32 w_inc     = 0;
+    i32 b_inc     = 0;
+    i32 move_time = 0;
 };
 
 class UCIHandler {
@@ -21,7 +21,7 @@ public:
     UCIHandler();
 
     void loop();
-    void handle_command_line(int argc, char* argv[]);
+    void handle_command_line(i32 argc, char* argv[]);
 
 private:
     Position m_position;

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -406,7 +406,7 @@ struct v512 {
         return a = a ^ b;
     }
 
-    forceinline auto operator==(const v512& other) const -> bool {
+    forceinline bool operator==(const v512& other) const {
         return raw == other.raw;
     }
 };

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -67,7 +67,7 @@ struct v128 {
         return blend8(mask0, blend8(mask1, w, x), blend8(mask1, y, z));
     }
 
-    static forceinline v128 shl16(v128 a, int shift) {
+    static forceinline v128 shl16(v128 a, i32 shift) {
         return {_mm_slli_epi16(a.raw, shift)};
     }
 
@@ -176,11 +176,11 @@ struct v256 {
         return blend8(mask0, x, y);
     }
 
-    static forceinline v256 shl16(v256 a, int shift) {
+    static forceinline v256 shl16(v256 a, i32 shift) {
         return {_mm256_slli_epi16(a.raw, shift)};
     }
 
-    static forceinline v256 shr16(v256 a, int shift) {
+    static forceinline v256 shr16(v256 a, i32 shift) {
         return {_mm256_srli_epi16(a.raw, shift)};
     }
 
@@ -225,7 +225,7 @@ struct v256 {
           static_cast<u32>(~_mm256_movemask_epi8(_mm256_cmpeq_epi16(a.raw, b.raw))), 0xAAAAAAAA));
     }
 
-    template<int offset>
+    template<i32 offset>
     [[nodiscard]] forceinline v128 extract128() const {
         return {_mm256_extracti128_si256(raw, offset)};
     }
@@ -320,7 +320,7 @@ struct v512 {
         return v512{v256::permute8(index.raw[0], a), v256::permute8(index.raw[1], a)};
     }
 
-    static forceinline v512 shr16(v512 a, int shift) {
+    static forceinline v512 shr16(v512 a, i32 shift) {
         return v512{v256::shr16(a.raw[0], shift), v256::shr16(a.raw[1], shift)};
     }
 
@@ -412,7 +412,7 @@ struct v512 {
 };
 static_assert(sizeof(v512) == 64);
 
-forceinline u16 findset8(v128 haystack, int haystack_len, v128 needles) {
+forceinline u16 findset8(v128 haystack, i32 haystack_len, v128 needles) {
     return static_cast<u16>(
       _mm_extract_epi16(_mm_cmpestrm(haystack.raw, haystack_len, needles.raw, 16, 0), 0));
 }

--- a/tests/test_perft.cpp
+++ b/tests/test_perft.cpp
@@ -11,7 +11,7 @@
 
 using namespace Clockwork;
 
-auto main() -> int {
+int main() {
     std::vector<std::tuple<std::string_view, std::vector<u64>>> cases{{
       {"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
        {{1, 48, 2039, 97862, 4085603}}},

--- a/tests/test_position.cpp
+++ b/tests/test_position.cpp
@@ -33,7 +33,7 @@ void roundtrip_classical_fens() {
     }
 }
 
-auto main() -> int {
+int main() {
     roundtrip_classical_fens();
     return 0;
 }


### PR DESCRIPTION
- Remove all usage of "int", except in main() function signatures
- Remove function signatures of the form "auto name() -> ReturnType"
- Move public contents above private contents in Position

Things that still need to be done:
- Get rid of any public fields where the type is not just a simple collection. 
  - If the variable needs to be accessed outside the class/struct, there should be an accessor
  - If the variable needs to be set outside the class, then there can be a discussion on it being public(but I don't think we have any situations like this)