### PR TITLE
Add space before inheritance colon

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,6 +49,6 @@ SortUsingDeclarations: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
-SpaceBeforeInheritanceColon: false
+SpaceBeforeInheritanceColon: true
 SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 2


### PR DESCRIPTION
So inheritance looks like this
```
class A : public B {}
```
and not like this
```
class A: public B {}
```
which is extremely ugly and I have never seen anyone use this style