### PR TITLE
Interleave ray toggling in incremental attack table updates

### DIFF
--- a/src/position.hpp
+++ b/src/position.hpp
@@ -129,6 +129,7 @@ private:
     void incrementally_add_piece(bool color, Place p, Square sq);
     void
     incrementally_mutate_piece(bool old_color, PieceId old_id, Square sq, bool new_color, Place p);
+    void incrementally_move_piece(bool color, Square from, Square to, Place p);
 
     void remove_attacks(bool color, PieceId id);
     v512 toggle_rays(Square sq);


### PR DESCRIPTION
+22% non-bulk perft speed

```
before: perft to depth 7 complete in 136239.9ms (23.5 Mnps)
after:  perft to depth 7 complete in 111413.8ms (28.7 Mnps)
```

we interleave `ray_toggle`s to take advantage of instruction level parallelism