### PR TITLE
Use unreachable

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -17,6 +17,7 @@ constexpr char color_char(Color color) {
     case Black:
         return 'b';
     }
+    unreachable();
 }
 
 constexpr Color invert(Color color) {
@@ -51,6 +52,7 @@ constexpr char piece_char(PieceType piece) {
     case King:
         return 'k';
     }
+    unreachable();
 }
 
 }

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -27,6 +27,7 @@ valid_pawns(Color color, Bitboard bb, Bitboard empty, Bitboard dests) {
                 single & Bitboard{0x000000000000FF00}, -8, -16};
     }
     }
+    unreachable();
 }
 
 void MoveGen::generate_moves(MoveList& moves) {
@@ -69,7 +70,8 @@ void MoveGen::generate_moves(MoveList& moves) {
         Square   king_sq   = m_position.king_sq(active_color);
         RookInfo rook_info = m_position.rook_info(active_color);
         if (rook_info.aside.is_valid()) {
-            Bitboard clear = empty | Bitboard::from_square(king_sq) | Bitboard::from_square(rook_info.aside);
+            Bitboard clear =
+              empty | Bitboard::from_square(king_sq) | Bitboard::from_square(rook_info.aside);
             u8 rank_empty = clear.front_rank(active_color);
             u8 rank_safe  = (~danger).front_rank(active_color);
             if ((rank_empty & 0x1F) == 0x1F && (rank_safe & 0x1C) == 0x1C) {

--- a/src/util/types.hpp
+++ b/src/util/types.hpp
@@ -3,8 +3,8 @@
 #include <cstddef>
 #include <cstdint>
 
-
 #define forceinline inline __attribute__((always_inline))
+#define unreachable() (__builtin_unreachable())
 
 namespace Clockwork {
 


### PR DESCRIPTION
`__builtin_unreachable()` is valid for clang and gcc.
msvc would require `__assume(false)` (if msvc support was a priority at all)