### PR TITLE
Only set Position::m_enpassant when ep is pseudolegal

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -225,7 +225,11 @@ Position Position::move(Move m) const {
         if (src.ptype() == PieceType::Pawn) {
             new_pos.m_50mr = 0;
             if (from.raw - to.raw == 16 || to.raw - from.raw == 16) {
-                new_pos.m_enpassant = Square{static_cast<u8>((from.raw + to.raw) / 2)};
+                Color  them = invert(m_active_color);
+                Square ep   = Square{static_cast<u8>((from.raw + to.raw) / 2)};
+                if (attack_table(them).read(ep) & piece_list(them).mask_eq(PieceType::Pawn)) {
+                    new_pos.m_enpassant = ep;
+                }
             }
         } else {
             new_pos.m_50mr++;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -227,7 +227,7 @@ Position Position::move(Move m) const {
             if (from.raw - to.raw == 16 || to.raw - from.raw == 16) {
                 Color  them = invert(m_active_color);
                 Square ep   = Square{static_cast<u8>((from.raw + to.raw) / 2)};
-                if (attack_table(them).read(ep) & piece_list(them).mask_eq(PieceType::Pawn)) {
+                if (is_square_attacked_by(ep, them, PieceType::Pawn)) {
                     new_pos.m_enpassant = ep;
                 }
             }

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -105,6 +105,10 @@ public:
         return std::popcount(piece_list(color).mask_eq(ptype));
     }
 
+    [[nodiscard]] bool is_square_attacked_by(Square sq, Color color, PieceType ptype) const {
+        return attack_table(color).read(sq) & piece_list(color).mask_eq(ptype);
+    }
+
     [[nodiscard]] Position move(Move m) const;
 
     const std::array<Wordboard, 2> calc_attacks_slow();


### PR DESCRIPTION
Most chess engines don't bother doing this, but since it's basically free as we have attack tables, why not.

This patch only sets `m_enpassant` when there is a enemy pawn that is pseudo-legally able to capture it by en-passant.

This allows for more accurate three-fold repetition detection in cases where en-passant is not possible, by not setting the Zorbrist ep key when ep is not possible.