### PR TITLE
TT-Move Ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,10 @@ set(srcs
         src/search.cpp
         src/search.hpp
         src/square.hpp
-        src/tm.hpp
         src/tm.cpp
+        src/tm.hpp
+        src/tt.cpp
+        src/tt.hpp
         src/uci.cpp
         src/uci.hpp
         src/zobrist.cpp

--- a/src/bench.hpp
+++ b/src/bench.hpp
@@ -1,5 +1,7 @@
 #include "search.hpp"
+#include "tt.hpp"
 #include "util/types.hpp"
+
 
 namespace Clockwork {
 namespace Bench {

--- a/src/movepick.hpp
+++ b/src/movepick.hpp
@@ -12,9 +12,10 @@ bool quiet_move(Move move);
 
 class MovePicker {
 public:
-    explicit MovePicker(const Position& pos) :
+    explicit MovePicker(const Position& pos, Move tt_move = Move::none()) :
         m_pos(pos),
-        m_movegen(pos) {
+        m_movegen(pos),
+        m_tt_move(tt_move) {
     }
 
     void skip_quiets();
@@ -24,6 +25,7 @@ public:
 private:
     enum class Stage {
         GenerateMoves,
+        EmitTTMove,
         EmitNoisy,
         EmitQuiet,
         End,
@@ -39,6 +41,8 @@ private:
     MoveList        m_quiet;
     usize           m_current_index = 0;
     bool            m_skip_quiets   = false;
+
+    Move m_tt_move;
 };
 
 }

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "move.hpp"
 #include "position.hpp"
+#include "tt.hpp"
 #include "uci.hpp"
 #include "util/types.hpp"
 
@@ -21,7 +22,7 @@ struct SearchLimits {
 class Worker {
 public:
     u64 search_nodes;
-    Worker() = default;
+    Worker(TT& tt);
     void launch_search(Position            root_position,
                        RepetitionInfo      repetition_info,
                        UCI::SearchSettings settings);
@@ -31,7 +32,9 @@ private:
     time::TimePoint m_search_start;
     SearchLimits    m_search_limits;
     RepetitionInfo  m_repetition_info;
-    Move            iterative_deepening(Position root_position);
+    TT&             m_tt;
+
+    Move iterative_deepening(Position root_position);
 
     Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, i32 ply);
     Value quiesce(Position& pos, Stack* ss, Value alpha, Value beta, i32 ply);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -1,0 +1,71 @@
+#include "tt.hpp"
+
+namespace Clockwork {
+
+uint64_t mulhi64(uint64_t a, uint64_t b) {
+    unsigned __int128 result =
+      static_cast<unsigned __int128>(a) * static_cast<unsigned __int128>(b);
+    return result >> 64;
+}
+
+void* aligned_alloc(size_t alignment, size_t size) {
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#else
+    return std::aligned_alloc(alignment, size);
+#endif
+}
+
+void aligned_free(void* ptr) {
+    if (ptr == nullptr) {
+        return;
+    }
+#ifdef _WIN32
+    return _aligned_free(ptr);
+#else
+    return std::free(ptr);
+#endif
+}
+
+TT::TT(size_t mb) :
+    m_entries{nullptr},
+    m_size{0} {
+    resize(mb);
+}
+
+TT::~TT() {
+    aligned_free(m_entries);
+}
+
+std::optional<TTData> TT::probe(const Position& pos) const {
+    size_t      idx   = mulhi64(pos.get_hash_key(), m_size);
+    const auto& entry = m_entries[idx];
+    if (entry.key == pos.get_hash_key()) {
+        TTData data = {.move = entry.move};
+        return {data};
+    }
+    return {};
+}
+
+void TT::store(const Position& pos, Move move) {
+    size_t idx   = mulhi64(pos.get_hash_key(), m_size);
+    auto&  entry = m_entries[idx];
+    entry.key    = pos.get_hash_key();
+    entry.move   = move;
+}
+
+void TT::resize(size_t mb) {
+    aligned_free(m_entries);
+
+    size_t entries = mb * 1024 * 1024 / sizeof(TTEntry);
+
+    m_size    = entries;
+    m_entries = static_cast<TTEntry*>(aligned_alloc(TT_ALIGNMENT, entries * sizeof(TTEntry)));
+    clear();
+}
+
+void TT::clear() {
+    std::memset(m_entries, 0, m_size * sizeof(TTEntry));
+}
+
+}

--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "position.hpp"
+
+namespace Clockwork {
+
+struct TTEntry {
+    HashKey key;
+    Move    move;
+};
+
+
+struct TTData {
+    Move move;
+};
+
+class TT {
+public:
+    static constexpr size_t DEFAULT_SIZE_MB = 16;
+    static constexpr size_t TT_ALIGNMENT    = 64;
+
+    TT(size_t mb = DEFAULT_SIZE_MB);
+    ~TT();
+
+    std::optional<TTData> probe(const Position& pos) const;
+    void                  store(const Position& pos, Move move);
+    void                  resize(size_t mb);
+    void                  clear();
+
+private:
+    TTEntry* m_entries;
+    size_t   m_size;
+};
+
+}

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -47,6 +47,8 @@ void UCIHandler::execute_command(const std::string& line) {
         std::cout << "id name Clockwork\n";
         std::cout << "id author The Clockwork community\n";
         std::cout << "uciok" << std::endl;
+    } else if (command == "ucinewgame") {
+        m_tt.clear();
     } else if (command == "isready") {
         std::cout << "readyok" << std::endl;
     } else if (command == "quit") {
@@ -74,7 +76,7 @@ void UCIHandler::handle_bench(std::istringstream& is) {
         is.clear();
         depth = 5;
     }
-    Search::Worker worker;
+    Search::Worker worker{m_tt};
     Bench::benchmark(worker, depth);
 }
 
@@ -106,7 +108,7 @@ void UCIHandler::handle_go(std::istringstream& is) {
             is >> settings.hard_nodes;
         }
     }
-    Search::Worker worker;
+    Search::Worker worker{m_tt};
     worker.launch_search(m_position, m_repetition_info, settings);
 }
 

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -6,6 +6,7 @@
 #include "common.hpp"
 #include "position.hpp"
 #include "repetition_info.hpp"
+#include "tt.hpp"
 
 namespace Clockwork::UCI {
 
@@ -31,6 +32,8 @@ public:
 private:
     Position       m_position;
     RepetitionInfo m_repetition_info;
+    // move this somewhere else later
+    TT m_tt;
 
     SearchSettings settings;
 


### PR DESCRIPTION
```
Elo   | 188.81 +- 29.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.15 (-2.94, 2.94) [0.00, 5.00]
Games | N: 454 W: 270 L: 45 D: 139
Penta | [2, 11, 54, 80, 80]
```
https://clockworkopenbench.pythonanywhere.com/test/17/

Issues to fix
- Missing a Hash option
- looping through all moves to check TT-move legality instead of directly checking legality
- TT is currently stored in UCI. There should be a better place to put it(e.g. a `Search` class/struct)

Bench: 37989346