### PR TITLE
MVV-LVA Move Ordering

### DIFF
--- a/src/movepick.hpp
+++ b/src/movepick.hpp
@@ -26,21 +26,27 @@ private:
     enum class Stage {
         GenerateMoves,
         EmitTTMove,
+        ScoreNoisy,
         EmitNoisy,
         EmitQuiet,
         End,
     };
 
     void generate_moves();
+    Move pick_next(MoveList& moves);
+    void score_moves(MoveList& moves);
+
+    i32 score_move(Move move) const;
 
     Stage m_stage = Stage::GenerateMoves;
 
-    const Position& m_pos;
-    MoveGen         m_movegen;
-    MoveList        m_noisy;
-    MoveList        m_quiet;
-    usize           m_current_index = 0;
-    bool            m_skip_quiets   = false;
+    const Position&      m_pos;
+    MoveGen              m_movegen;
+    MoveList             m_noisy;
+    MoveList             m_quiet;
+    usize                m_current_index = 0;
+    bool                 m_skip_quiets   = false;
+    std::array<i32, 256> m_scores;
 
     Move m_tt_move;
 };

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -101,6 +101,10 @@ public:
         return piece_list_sq(color)[PieceId{0}];
     }
 
+    [[nodiscard]] PieceType piece_at(Square sq) const {
+        return m_board[sq].ptype();
+    }
+
     [[nodiscard]] bool is_valid() const {
         return attack_table(m_active_color).read(king_sq(invert(m_active_color))) == 0;
     }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -71,10 +71,10 @@ void UCIHandler::execute_command(const std::string& line) {
 }
 
 void UCIHandler::handle_bench(std::istringstream& is) {
-    Depth depth = 5;
+    Depth depth = 6;
     if (!(is >> depth)) {
         is.clear();
-        depth = 5;
+        depth = 6;
     }
     Search::Worker worker{m_tt};
     Bench::benchmark(worker, depth);


### PR DESCRIPTION
Also increased bench depth to 6
```
Elo   | 54.15 +- 16.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1132 W: 493 L: 318 D: 321
Penta | [38, 84, 203, 147, 94]
```
https://clockworkopenbench.pythonanywhere.com/test/18/

Bench: 46522118