### PR TITLE
Avoid storing invalid moves in tt

### DIFF
--- a/src/search.hpp
+++ b/src/search.hpp
@@ -39,7 +39,7 @@ private:
     Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, i32 ply);
     Value quiesce(Position& pos, Stack* ss, Value alpha, Value beta, i32 ply);
     Value evaluate(const Position& pos);
-    void  check_tm_hard_limit();
+    bool  check_tm_hard_limit();
 };
 }
 }


### PR DESCRIPTION
Move stop check into move loop (terminate loop early on stopping).
This also ensures we return before we do an invalid tt store.

```
Elo   | 1.61 +- 3.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.10 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 18522 W: 6537 L: 6451 D: 5534
Penta | [952, 1874, 3556, 1894, 985]
```

bench 46522118