### PR TITLE
TT Cutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -171,7 +171,13 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         return 0;
     }
 
-    auto tt_data = m_tt.probe(pos);
+    auto tt_data = m_tt.probe(pos, ply);
+    if (tt_data && tt_data->depth >= depth
+        && (tt_data->bound == Bound::Exact
+            || (tt_data->bound == Bound::Lower && tt_data->score >= beta)
+            || (tt_data->bound == Bound::Upper && tt_data->score <= alpha))) {
+        return tt_data->score;
+    }
 
     MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none()};
     Move       best_move  = Move::none();
@@ -225,7 +231,10 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         }
     }
 
-    m_tt.store(pos, best_move);
+    Bound bound = best_value >= beta        ? Bound::Lower
+                : best_move != Move::none() ? Bound::Exact
+                                            : Bound::Upper;
+    m_tt.store(pos, ply, best_move, best_value, depth, bound);
 
     return best_value;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -182,7 +182,6 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none()};
     Move       best_move  = Move::none();
     Value      best_value = -VALUE_INF;
-    Bound      bound      = Bound::Upper;
 
     // Iterate over the move list
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
@@ -211,10 +210,8 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             if (value > alpha) {
                 alpha     = value;
                 best_move = m;
-                bound     = Bound::Exact;
 
                 if (value >= beta) {
-                    bound = Bound::Lower;
                     break;
                 }
             }
@@ -234,9 +231,9 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         }
     }
 
-    // Bound bound = best_value >= beta        ? Bound::Lower
-    //             : best_move != Move::none() ? Bound::Exact
-    //                                         : Bound::Upper;
+    Bound bound = best_value >= beta        ? Bound::Lower
+                : best_move != Move::none() ? Bound::Exact
+                                            : Bound::Upper;
     m_tt.store(pos, ply, best_move, best_value, depth, bound);
 
     return best_value;

--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -4,14 +4,27 @@
 
 namespace Clockwork {
 
+enum Bound : u8 {
+    None,
+    Lower,
+    Upper,
+    Exact,
+};
+
 struct TTEntry {
     HashKey key;
     Move    move;
+    i16     score;
+    u8      depth;
+    Bound   bound;
 };
 
 
 struct TTData {
-    Move move;
+    Move  move;
+    Value score;
+    Depth depth;
+    Bound bound;
 };
 
 class TT {
@@ -22,10 +35,10 @@ public:
     TT(size_t mb = DEFAULT_SIZE_MB);
     ~TT();
 
-    std::optional<TTData> probe(const Position& pos) const;
-    void                  store(const Position& pos, Move move);
-    void                  resize(size_t mb);
-    void                  clear();
+    std::optional<TTData> probe(const Position& pos, i32 ply) const;
+    void store(const Position& pos, i32 ply, Move move, Value score, Depth depth, Bound bound);
+    void resize(size_t mb);
+    void clear();
 
 private:
     TTEntry* m_entries;


### PR DESCRIPTION
```
Elo   | 64.07 +- 18.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1042 W: 490 L: 300 D: 252
Penta | [46, 61, 183, 119, 112]
```
https://clockworkopenbench.pythonanywhere.com/test/32/

Need to change !root to !pvNode once we have PVS

Bench: 20874551