### PR TITLE
Reverse Futility Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -179,6 +179,13 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         return tt_data->score;
     }
 
+    bool  is_in_check = pos.is_in_check();
+    Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
+
+    if (!ROOT_NODE && !is_in_check && depth <= 6 && static_eval >= beta + 80 * depth) {
+        return static_eval;
+    }
+
     MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none()};
     Move       best_move  = Move::none();
     Value      best_value = -VALUE_INF;


### PR DESCRIPTION
```
Elo   | 56.80 +- 16.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1154 W: 510 L: 323 D: 321
Penta | [46, 74, 203, 155, 99]
```
https://clockworkopenbench.pythonanywhere.com/test/33/

Bench: 12210264