### PR TITLE
Check extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -199,7 +199,8 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         m_repetition_info.push(pos_after.get_hash_key(), pos_after.is_reversible(m));
 
         // Get search value
-        Value value = -search(pos_after, ss + 1, -beta, -alpha, depth - 1, ply + 1);
+        Depth new_depth = depth - 1 + pos_after.is_in_check();
+        Value value     = -search(pos_after, ss + 1, -beta, -alpha, new_depth, ply + 1);
 
         // TODO: encapsulate this and any other future adjustment to do "on going back" into a proper function
         m_repetition_info.pop();


### PR DESCRIPTION
```
Elo   | 14.94 +- 8.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4492 W: 1657 L: 1464 D: 1371
Penta | [204, 469, 800, 476, 297]
```
https://clockworkopenbench.pythonanywhere.com/test/35/

Bench: 14297447