### PR TITLE
Null Move Pruning

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -364,6 +364,22 @@ Position Position::move(Move m) const {
     return new_pos;
 }
 
+Position Position::null_move() const {
+    Position new_pos = *this;
+    new_pos.m_hash_key ^= Zobrist::side_key;
+
+    if (m_enpassant.is_valid()) {
+        // Remove hash for ep square
+        new_pos.m_hash_key ^= Zobrist::en_passant_zobrist[new_pos.m_enpassant.raw];
+        new_pos.m_enpassant = Square::invalid();
+    }
+
+    new_pos.m_active_color = invert(m_active_color);
+    new_pos.m_ply++;
+
+    return new_pos;
+}
+
 std::tuple<Wordboard, Bitboard> Position::calc_pin_mask() const {
     Square king_square = king_sq(m_active_color);
 

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -130,6 +130,7 @@ public:
     }
 
     [[nodiscard]] Position move(Move m) const;
+    [[nodiscard]] Position null_move() const;
 
     [[nodiscard]] std::tuple<Wordboard, Bitboard> calc_pin_mask() const;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -194,6 +194,8 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
 
         Value value = -search(pos_after, ss + 1, -beta, -beta + 1, depth - R, ply + 1);
 
+        m_repetition_info.pop();
+
         if (value >= beta) {
             return value > VALUE_WIN ? beta : value;
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -186,6 +186,19 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         return static_eval;
     }
 
+    if (!ROOT_NODE && !is_in_check && depth >= 3) {
+        int      R         = 3;
+        Position pos_after = pos.null_move();
+
+        m_repetition_info.push(pos_after.get_hash_key(), true);
+
+        Value value = -search(pos_after, ss + 1, -beta, -beta + 1, depth - R, ply + 1);
+
+        if (value >= beta) {
+            return value > VALUE_WIN ? beta : value;
+        }
+    }
+
     MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none()};
     Move       best_move  = Move::none();
     Value      best_value = -VALUE_INF;


### PR DESCRIPTION
```
Elo   | 86.28 +- 21.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 752 W: 366 L: 183 D: 203
Penta | [18, 51, 125, 94, 88]
```
https://clockworkopenbench.pythonanywhere.com/test/40/

Bench: 9492918