### PR TITLE
Simple mobility

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -184,8 +184,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
 
     // Reuse TT score as a better positional evaluation
     auto tt_adjusted_eval = static_eval;
-    if (tt_data
-        && tt_data->bound != (tt_data->score > static_eval ? Bound::Upper : Bound::Lower)) {
+    if (tt_data && tt_data->bound != (tt_data->score > static_eval ? Bound::Upper : Bound::Lower)) {
         tt_adjusted_eval = tt_data->score;
     }
 
@@ -366,12 +365,25 @@ Value Worker::quiesce(Position& pos, Stack* ss, Value alpha, Value beta, i32 ply
 Value Worker::evaluate(const Position& pos) {
     const Color us   = pos.active_color();
     const Color them = invert(us);
-    return 100 * (pos.piece_count(us, PieceType::Pawn) - pos.piece_count(them, PieceType::Pawn))
-         + 330 * (pos.piece_count(us, PieceType::Knight) - pos.piece_count(them, PieceType::Knight))
-         + 370 * (pos.piece_count(us, PieceType::Bishop) - pos.piece_count(them, PieceType::Bishop))
-         + 550 * (pos.piece_count(us, PieceType::Rook) - pos.piece_count(them, PieceType::Rook))
-         + 1000 * (pos.piece_count(us, PieceType::Queen) - pos.piece_count(them, PieceType::Queen))
-         + static_cast<i32>(search_nodes & 7) - 3;
+
+    Value material =
+      100 * (pos.piece_count(us, PieceType::Pawn) - pos.piece_count(them, PieceType::Pawn))
+      + 330 * (pos.piece_count(us, PieceType::Knight) - pos.piece_count(them, PieceType::Knight))
+      + 370 * (pos.piece_count(us, PieceType::Bishop) - pos.piece_count(them, PieceType::Bishop))
+      + 550 * (pos.piece_count(us, PieceType::Rook) - pos.piece_count(them, PieceType::Rook))
+      + 1000 * (pos.piece_count(us, PieceType::Queen) - pos.piece_count(them, PieceType::Queen));
+
+    Value mobility = 0;
+    for (u64 x : std::bit_cast<std::array<u64, 16>>(pos.attack_table(us))) {
+        mobility += 10 * std::popcount(x);
+    }
+    for (u64 x : std::bit_cast<std::array<u64, 16>>(pos.attack_table(them))) {
+        mobility -= 10 * std::popcount(x);
+    }
+
+    Value fudge = static_cast<i32>(search_nodes & 7) - 3;
+
+    return material + mobility + fudge;
 }
 }
 }


### PR DESCRIPTION
Very very basic mobility. Scores all possible attacks 10cp. Very simple implementation; we do a popcount of the attack tables and multiply by 10.

```
Elo   | 227.95 +- 37.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 396 W: 278 L: 50 D: 68
Penta | [2, 9, 42, 49, 96]
```

bench: 6939040