### PR TITLE
Better history bonus formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,8 +188,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
 
     // Reuse TT score as a better positional evaluation
     auto tt_adjusted_eval = static_eval;
-    if (tt_data
-        && tt_data->bound != (tt_data->score > static_eval ? Bound::Upper : Bound::Lower)) {
+    if (tt_data && tt_data->bound != (tt_data->score > static_eval ? Bound::Upper : Bound::Lower)) {
         tt_adjusted_eval = tt_data->score;
     }
 
@@ -263,9 +262,10 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     if (best_value >= beta && quiet_move(best_move)) {
         ss->killer = best_move;
 
-        m_td.history.update_quiet_stats(pos, best_move, depth * depth);
+        const i32 bonus = std::min(1896, 4 * depth * depth + 120 * depth - 120);
+        m_td.history.update_quiet_stats(pos, best_move, bonus);
         for (Move quiet : quiets_played) {
-            m_td.history.update_quiet_stats(pos, quiet, -depth * depth);
+            m_td.history.update_quiet_stats(pos, quiet, -bonus);
         }
     }
 


### PR DESCRIPTION
Old formula from Berserk
```
Elo   | 17.65 +- 9.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3724 W: 1416 L: 1227 D: 1081
Penta | [176, 361, 666, 416, 243]
```
https://clockworkopenbench.pythonanywhere.com/test/63/

Bench: 8056810