### PR TITLE
LMR

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -71,10 +71,10 @@ void UCIHandler::execute_command(const std::string& line) {
 }
 
 void UCIHandler::handle_bench(std::istringstream& is) {
-    Depth depth = 6;
+    Depth depth = 8;
     if (!(is >> depth)) {
         is.clear();
-        depth = 6;
+        depth = 8;
     }
     Search::ThreadData td = {};
     Search::Worker     worker{m_tt, td};


### PR DESCRIPTION
Increased bench depth to 8
```
Elo   | 33.66 +- 12.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1812 W: 728 L: 553 D: 531
Penta | [72, 149, 344, 214, 127]
```
https://clockworkopenbench.pythonanywhere.com/test/70/

Bench: 11374063