### PR TITLE
Log lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -235,7 +235,8 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         Depth new_depth = depth - 1 + pos_after.is_in_check();
         Value value;
         if (depth >= 3 && moves_played >= 4 && quiet) {
-            i32   reduction     = 1;
+            i32 reduction =
+              static_cast<i32>(0.77 + std::log(depth) * std::log(moves_played) / 2.36);
             Depth reduced_depth = std::min(std::max(new_depth - reduction, 1), new_depth);
             value = -search<false>(pos_after, ss + 1, -alpha - 1, -alpha, reduced_depth, ply + 1);
             if (value > alpha && reduced_depth < new_depth) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -7,8 +7,10 @@
 #include "uci.hpp"
 #include "util/types.hpp"
 #include <array>
+#include <cmath>
 #include <iostream>
 #include <limits>
+
 
 namespace Clockwork {
 namespace Search {


### PR DESCRIPTION
```
Elo   | 17.88 +- 8.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3520 W: 1287 L: 1106 D: 1127
Penta | [144, 334, 672, 417, 193]
```
https://clockworkopenbench.pythonanywhere.com/test/72/

Bench: 5154950