### PR TITLE
lmr less in PV nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -239,6 +239,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         if (depth >= 3 && moves_played >= 4 && quiet) {
             i32 reduction =
               static_cast<i32>(0.77 + std::log(depth) * std::log(moves_played) / 2.36);
+            reduction -= PV_NODE;
             Depth reduced_depth = std::min(std::max(new_depth - reduction, 1), new_depth);
             value = -search<false>(pos_after, ss + 1, -alpha - 1, -alpha, reduced_depth, ply + 1);
             if (value > alpha && reduced_depth < new_depth) {


### PR DESCRIPTION
```
Elo   | 8.55 +- 5.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8130 W: 2748 L: 2548 D: 2834
Penta | [334, 853, 1536, 963, 379]
```
https://clockworkopenbench.pythonanywhere.com/test/74/

bench: 7573112