### PR TITLE
Add tunable options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: Consecutive
 AlignConsecutiveDeclarations: Consecutive
-AlignEscapedNewlines: DontAlign
+AlignEscapedNewlines: LeftWithLastLine
 AlignOperands: AlignAfterOperator
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,11 +82,14 @@ set(srcs
         src/tm.hpp
         src/tt.cpp
         src/tt.hpp
+        src/tuned.cpp
+        src/tuned.hpp
         src/uci.cpp
         src/uci.hpp
         src/zobrist.cpp
         src/zobrist.hpp
         src/util/bit.hpp
+        src/util/parse.hpp
         src/util/static_vector.hpp
         src/util/types.hpp
         src/util/vec.hpp

--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -1,5 +1,4 @@
 #include "bench.hpp"
-#include "search.h"
 #include "search.hpp"
 #include "uci.hpp"
 #include "util/types.hpp"

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -4,13 +4,13 @@
 #include "movegen.hpp"
 #include "movepick.hpp"
 #include "tm.hpp"
+#include "tuned.hpp"
 #include "uci.hpp"
 #include "util/types.hpp"
 #include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
-
 
 namespace Clockwork {
 namespace Search {
@@ -195,12 +195,13 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         tt_adjusted_eval = tt_data->score;
     }
 
-    if (!PV_NODE && !is_in_check && depth <= 6 && tt_adjusted_eval >= beta + 80 * depth) {
+    if (!PV_NODE && !is_in_check && depth <= tuned::rfp_depth
+        && tt_adjusted_eval >= beta + tuned::rfp_margin * depth) {
         return tt_adjusted_eval;
     }
 
-    if (!PV_NODE && !is_in_check && depth >= 3) {
-        int      R         = 3;
+    if (!PV_NODE && !is_in_check && depth >= tuned::nmp_depth) {
+        int      R         = tuned::nmp_base_r;
         Position pos_after = pos.null_move();
 
         m_repetition_info.push(pos_after.get_hash_key(), true);

--- a/src/tuned.cpp
+++ b/src/tuned.cpp
@@ -20,9 +20,14 @@ void uci_print_tunable_options() {
 }
 
 void uci_print_tunable_values() {
-#define PRINT_VALUE(NAME, ...) std::cout << #NAME << " = " << NAME << std::endl;
-    CLOCKWORK_TUNABLES(PRINT_VALUE, PRINT_VALUE)
-#undef PRINT_VALUE
+#define TUNE(NAME, DEFAULTVAL, MINVAL, MAXVAL, CEND, REND)                                \
+    std::cout << "tune_" #NAME ", int, " #DEFAULTVAL ", " #MINVAL ", " #MAXVAL ", " #CEND \
+                 ", " #REND                                                               \
+              << std::endl;
+#define NO_TUNE(...) /* do nothing */
+    CLOCKWORK_TUNABLES(TUNE, NO_TUNE)
+#undef TUNE
+#undef NO_TUNE
 }
 
 bool uci_parse_tunable([[maybe_unused]] std::string_view name,

--- a/src/tuned.cpp
+++ b/src/tuned.cpp
@@ -30,7 +30,7 @@ bool uci_parse_tunable([[maybe_unused]] std::string_view name,
 #if CLOCKWORK_IS_TUNING
     #define TUNE(NAME, DEFAULTVAL, MINVAL, MAXVAL, ...)         \
         if (name == "tune_" #NAME) {                            \
-            if (auto value = parse_i32(value_str)) {            \
+            if (auto value = parse_number<i32>(value_str)) {    \
                 NAME = std::clamp<i32>(*value, MINVAL, MAXVAL); \
                 return true;                                    \
             } else {                                            \

--- a/src/tuned.cpp
+++ b/src/tuned.cpp
@@ -1,0 +1,47 @@
+#include "tuned.hpp"
+#include "util/parse.hpp"
+#include <algorithm>
+#include <iostream>
+#include <string_view>
+
+namespace Clockwork::tuned {
+
+void uci_print_tunable_options() {
+#if CLOCKWORK_IS_TUNING
+    #define TUNE(NAME, DEFAULTVAL, MINVAL, MAXVAL, ...)                                          \
+        std::cout << "option name tune_" #NAME " type spin default " #DEFAULTVAL " min " #MINVAL \
+                     " max " #MAXVAL                                                             \
+                  << std::endl;
+    #define NO_TUNE(...) /* do nothing */
+    CLOCKWORK_TUNABLES(TUNE, NO_TUNE)
+    #undef TUNE
+    #undef NO_TUNE
+#endif
+}
+
+void uci_print_tunable_values() {
+#define PRINT_VALUE(NAME, ...) std::cout << #NAME << " = " << NAME << std::endl;
+    CLOCKWORK_TUNABLES(PRINT_VALUE, PRINT_VALUE)
+#undef PRINT_VALUE
+}
+
+bool uci_parse_tunable([[maybe_unused]] std::string_view name,
+                       [[maybe_unused]] std::string_view value_str) {
+#if CLOCKWORK_IS_TUNING
+    #define TUNE(NAME, DEFAULTVAL, MINVAL, MAXVAL, ...)         \
+        if (name == "tune_" #NAME) {                            \
+            if (auto value = parse_i32(value_str)) {            \
+                NAME = std::clamp<i32>(*value, MINVAL, MAXVAL); \
+                return true;                                    \
+            } else {                                            \
+                return false;                                   \
+            }                                                   \
+        }
+    #define NO_TUNE(...) /* do nothing */
+    CLOCKWORK_TUNABLES(TUNE, NO_TUNE)
+    #undef TUNE
+    #undef NO_TUNE
+#endif
+    return false;
+}
+}

--- a/src/tuned.hpp
+++ b/src/tuned.hpp
@@ -1,0 +1,40 @@
+#include "util/types.hpp"
+#include <string_view>
+
+#ifndef CLOCKWORK_IS_TUNING
+    #define CLOCKWORK_IS_TUNING 0
+#endif
+
+namespace Clockwork::tuned {
+
+#define CLOCKWORK_TUNABLES(TUNE, NO_TUNE)    \
+                                             \
+    /* RFP Values */                         \
+    TUNE(rfp_margin, 80, 40, 160, 4, 0.002)  \
+    NO_TUNE(rfp_depth, 6, 4, 10, .5, 0.002)  \
+                                             \
+    /* NMP Values */                         \
+    NO_TUNE(nmp_depth, 3, 1, 10, .5, 0.002)  \
+    NO_TUNE(nmp_base_r, 3, 1, 10, .5, 0.002) \
+                                             \
+    /* End of Tunables */
+
+#define DEFINE_VARIABLE(NAME, DEFAULT, ...) inline i32 NAME = DEFAULT;
+#define DEFINE_CONSTANT(NAME, DEFAULT, ...) constexpr i32 NAME = DEFAULT;
+
+#if CLOCKWORK_IS_TUNING
+// TUNEs are defined as variables, NO_TUNEs are defined as constexpr constants.
+CLOCKWORK_TUNABLES(DEFINE_VARIABLE, DEFINE_CONSTANT)
+#else
+// Both TUNEs and NO_TUNEs are defined as constexpr constants.
+CLOCKWORK_TUNABLES(DEFINE_CONSTANT, DEFINE_CONSTANT)
+#endif
+
+#undef DEFINE_VARIABLE
+#undef DEFINE_CONSTANT
+
+void uci_print_tunable_options();
+void uci_print_tunable_values();
+bool uci_parse_tunable(std::string_view name, std::string_view value);
+
+}

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -3,7 +3,6 @@
 #include "move.hpp"
 #include "perft.hpp"
 #include "position.hpp"
-#include "search.h"
 #include "search.hpp"
 #include "tuned.hpp"
 #include "util/parse.hpp"

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -68,7 +68,7 @@ void UCIHandler::execute_command(const std::string& line) {
         std::cout << m_position << std::endl;
     } else if (command == "attacks") {
         handle_attacks(is);
-    } else if (command == "tunables") {
+    } else if (command == "tunables" || command == "tunestr") {
         tuned::uci_print_tunable_values();
     } else if (command == "perft") {
         handle_perft(is);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -6,6 +6,7 @@
 #include "search.h"
 #include "search.hpp"
 #include "tuned.hpp"
+#include "util/parse.hpp"
 #include <algorithm>
 #include <ios>
 #include <iostream>
@@ -45,6 +46,8 @@ void UCIHandler::execute_command(const std::string& line) {
     if (command == "uci") {
         std::cout << "id name Clockwork\n";
         std::cout << "id author The Clockwork community\n";
+        std::cout << "option name Threads type spin default 1 min 1 max 1024\n";
+        std::cout << "option name Hash type spin default 16 min 1 max 268435456\n";
         tuned::uci_print_tunable_options();
         std::cout << "uciok" << std::endl;
     } else if (command == "ucinewgame") {
@@ -180,9 +183,17 @@ void UCIHandler::handle_setoption(std::istringstream& is) {
     is >> value_str;
 
     if (name == "Hash") {
-        // TODO
+        if (auto value = parse_i32(value_str)) {
+            m_tt.resize(static_cast<usize>(std::max(1, *value)));
+        } else {
+            std::cout << "Invalid value " << value_str << std::endl;
+        }
     } else if (name == "Threads") {
-        // TODO
+        if (auto value = parse_i32(value_str)) {
+            // TODO: change thread count
+        } else {
+            std::cout << "Invalid value " << value_str << std::endl;
+        }
     } else if (tuned::uci_parse_tunable(name, value_str)) {
         // Successfully parsed tunable
     } else {

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -41,6 +41,7 @@ private:
     void handle_bench(std::istringstream&);
     void handle_go(std::istringstream&);
     void handle_position(std::istringstream&);
+    void handle_setoption(std::istringstream&);
     void handle_attacks(std::istringstream&);
     void handle_perft(std::istringstream&);
 };

--- a/src/util/parse.hpp
+++ b/src/util/parse.hpp
@@ -3,11 +3,14 @@
 #include <optional>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 
 namespace Clockwork {
 
 template<typename T>
 inline std::optional<T> parse_number(std::string_view s) {
+    static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>);
+
     T value{};
 #if __cpp_lib_to_chars >= 202306L
     if (std::from_chars(s.data(), s.data() + s.size(), value)) {

--- a/src/util/parse.hpp
+++ b/src/util/parse.hpp
@@ -1,0 +1,22 @@
+#include "util/types.hpp"
+#include <charconv>
+#include <optional>
+#include <string_view>
+#include <system_error>
+
+namespace Clockwork {
+
+inline std::optional<i32> parse_i32(std::string_view s) {
+    i32 value = 0;
+#if __cpp_lib_to_chars >= 202306L
+    if (std::from_chars(s.data(), s.data() + s.size(), value)) {
+#else
+    if (std::from_chars(s.data(), s.data() + s.size(), value).ec == std::errc{}) {
+#endif
+        return value;
+    } else {
+        return std::nullopt;
+    }
+}
+
+}

--- a/src/util/parse.hpp
+++ b/src/util/parse.hpp
@@ -6,8 +6,9 @@
 
 namespace Clockwork {
 
-inline std::optional<i32> parse_i32(std::string_view s) {
-    i32 value = 0;
+template<typename T>
+inline std::optional<T> parse_number(std::string_view s) {
+    T value{};
 #if __cpp_lib_to_chars >= 202306L
     if (std::from_chars(s.data(), s.data() + s.size(), value)) {
 #else


### PR DESCRIPTION
Add some search tuning infrastructure.

Also adds the non-standard UCI command `tunables` which prints all current values of all tunables.

`CLOCKWORK_IS_TUNING` determines if tunables are variable.

The `/* End of Tunables */` comment is mainly so last `TUNE` line will end in a backslash so items can be reordered without having to think about backslashes.

```
> uci
< id name Clockwork
< id author The Clockwork community
< option name tune_rfp_margin type spin default 80 min 40 max 160
< uciok
> setoption name tune_rfp_margin value 100
> tunables
< rfp_margin = 100
< rfp_depth = 6
< nmp_depth = 3
< nmp_base_r = 3
```