### PR TITLE
Razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -215,6 +215,13 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         }
     }
 
+    // Razoring
+    if (!PV_NODE && depth <= 7 && static_eval + 260 * depth < alpha) {
+        const Value razor_score = quiesce(pos, ss, alpha, beta, ply);
+        if (razor_score <= alpha)
+            return razor_score;
+    }
+
     MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none(), ss->killer};
     Move       best_move    = Move::none();
     Value      best_value   = -VALUE_INF;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -216,7 +216,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     }
 
     // Razoring
-    if (!PV_NODE && depth <= 7 && static_eval + 260 * depth < alpha) {
+    if (!PV_NODE && !is_in_check && depth <= 7 && static_eval + 260 * depth < alpha) {
         const Value razor_score = quiesce(pos, ss, alpha, beta, ply);
         if (razor_score <= alpha)
             return razor_score;


### PR DESCRIPTION
Elo   | 10.72 +- 6.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6454 W: 2234 L: 2035 D: 2185
Penta | [264, 659, 1242, 738, 324]
https://clockworkopenbench.pythonanywhere.com/test/81/
