### PR TITLE
Late Move Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -233,8 +233,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
                 continue;
             }
             // TO:DO Suggestion: LMP
-
-            
+        
             // TO:DO Suggestion: Quiet History Pruning
         }
         

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -236,7 +236,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             // Late Move Pruning (LMP)
             if (moves_played >= lmp_threshold) {                    
                 continue;
-            }
+            }        
             // TO:DO Suggestion: FP
             
         

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -228,12 +228,13 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
 
-        if (quiet) {
+        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {
             if (depth <= 4 && !PV_NODE && !is_in_check && static_eval + 100 * depth <= alpha) {
                 continue;
             }
             // TO:DO Suggestion: LMP
 
+            
             // TO:DO Suggestion: Quiet History Pruning
         }
         

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -229,10 +229,16 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         bool quiet = quiet_move(m);
 
         if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {
-            if (depth <= 5 && !PV_NODE && !is_in_check && static_eval + 80 * depth <= alpha) {
+            int lmp_base = 4;
+            int lmp_multiplier = 3;
+            int lmp_threshold = (lmp_base + lmp_multiplier * depth * depth);
+
+            // Late Move Pruning (LMP)
+            if (moves_played >= lmp_threshold) {                    
                 continue;
             }
-            // TO:DO Suggestion: LMP
+            // TO:DO Suggestion: FP
+            
         
             // TO:DO Suggestion: Quiet History Pruning
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -227,6 +227,17 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     // Iterate over the move list
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
+
+        if (quiet) {
+            if (depth <= 4 && !PV_NODE && !is_in_check && static_eval 100 * depth <= alpha) {
+                continue;
+            }
+
+            // TO:DO Suggestion: LMP
+
+            // TO:DO Suggestion: Quiet History Pruning
+        }
+        
         // Do move
         Position pos_after = pos.move(m);
         moves_played++;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -229,7 +229,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         bool quiet = quiet_move(m);
 
         if (quiet) {
-            if (depth <= 4 && !PV_NODE && !is_in_check && static_eval 100 * depth <= alpha) {
+            if (depth <= 4 && !PV_NODE && !is_in_check && static_eval + 100 * depth <= alpha) {
                 continue;
             }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -228,7 +228,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
 
-        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {            
+        if (!ROOT_NODE && best_value > -VALUE_WIN && quiet) {            
             // Late Move Pruning (LMP)
             if (moves_played >= 4 + 3 * depth * depth) {                    
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -232,7 +232,6 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             if (depth <= 4 && !PV_NODE && !is_in_check && static_eval + 100 * depth <= alpha) {
                 continue;
             }
-
             // TO:DO Suggestion: LMP
 
             // TO:DO Suggestion: Quiet History Pruning

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -229,11 +229,12 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         bool quiet = quiet_move(m);
 
         if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {
-            if (depth <= 4 && !PV_NODE && !is_in_check && static_eval + 100 * depth <= alpha) {
+            if (depth <= 5 && !PV_NODE && !is_in_check && static_eval + 80 * depth <= alpha) {
                 continue;
             }
             // TO:DO Suggestion: LMP
         
+            
             // TO:DO Suggestion: Quiet History Pruning
         }
         

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -234,7 +234,6 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             }
             // TO:DO Suggestion: LMP
         
-            
             // TO:DO Suggestion: Quiet History Pruning
         }
         

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -228,19 +228,11 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
 
-        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {
-            int lmp_base = 4;
-            int lmp_multiplier = 3;
-            int lmp_threshold = (lmp_base + lmp_multiplier * depth * depth);
-
+        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {            
             // Late Move Pruning (LMP)
-            if (moves_played >= lmp_threshold) {                    
+            if (moves_played >= 4 + 3 * depth * depth) {                    
                 continue;
-            }        
-            // TO:DO Suggestion: FP
-            
-        
-            // TO:DO Suggestion: Quiet History Pruning
+            }                  
         }
         
         // Do move

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -240,13 +240,13 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
 
-        if (!ROOT_NODE && best_value > -VALUE_WIN && quiet) {            
+        if (!ROOT_NODE && best_value > -VALUE_WIN && quiet) {
             // Late Move Pruning (LMP)
-            if (moves_played >= 4 + 3 * depth * depth) {                    
+            if (moves_played >= 4 + 3 * depth * depth) {
                 continue;
-            }                  
+            }
         }
-        
+
         // Do move
         Position pos_after = pos.move(m);
         moves_played++;


### PR DESCRIPTION
Elo   | 38.57 +- 13.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1574 W: 629 L: 455 D: 490
Penta | [63, 122, 283, 216, 103]

https://clockworkopenbench.pythonanywhere.com/test/86/

bench: 5416547