### PR TITLE
Internal Iterative Reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -190,7 +190,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
     // Internal Iterative Reductions
-    if (PV_NODE && depth >= 8 && tt_data->move != Move::none()) {
+    if (PV_NODE && depth >= 8 && tt_data->move == Move::none()) {
         depth--;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -191,6 +191,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
 
     // Internal Iterative Reductions
     if (PV_NODE && depth >= 8 && tt_data->move == Move::none()) {
+        printf("IIR sane check\n");
         depth--;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -190,8 +190,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
     // Internal Iterative Reductions
-    if (PV_NODE && depth >= 8 && tt_data->move == Move::none()) {
-        printf("IIR sane check\n");
+    if (PV_NODE && depth >= 8 && tt_data->move == Move::none()) {        
         depth--;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -190,7 +190,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
     // Internal Iterative Reductions
-    if (PV_NODE && depth >= 8 && tt_data->move == Move::none()) {        
+    if (PV_NODE && depth >= 8 && (!tt_data || tt_data->move == Move::none())) {
         depth--;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -190,9 +190,10 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
     // Internal Iterative Reductions
-    if (PV_NODE && depth >= 8 && !tt_data->move) {
+    if (PV_NODE && depth >= 8 && tt_data->move != Move::none()) {
         depth--;
     }
+
     
 
     // Reuse TT score as a better positional evaluation

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,6 +189,12 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     bool  is_in_check = pos.is_in_check();
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
+    // Internal Iterative Reductions
+    if (PV_NODE && depth >= 8 && !tt_data->move) {
+        depth--;
+    }
+    
+
     // Reuse TT score as a better positional evaluation
     auto tt_adjusted_eval = static_eval;
     if (tt_data && tt_data->bound != (tt_data->score > static_eval ? Bound::Upper : Bound::Lower)) {


### PR DESCRIPTION
Elo   | 35.73 +- 12.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1698 W: 649 L: 475 D: 574
Penta | [58, 158, 289, 240, 104]

https://clockworkopenbench.pythonanywhere.com/test/87/

bench: 7573112
