### PR TITLE
Quiet History Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -237,8 +237,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
 
         auto move_history = m_td.history.get_quiet_stats(pos, m);
 
-        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {
-            
+        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {            
             // Quiet History Pruning
             if (depth <= 4 && !is_in_check && move_history < depth * -2048) {
                 break;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -234,6 +234,17 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     // Iterate over the move list
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
+
+        auto move_history = m_td.history.get_quiet_stats(pos, m);
+
+        if (quiet && !ROOT_NODE && best_value > -VALUE_WIN) {
+            
+            // Quiet History Pruning
+            if (depth <= 4 && !is_in_check && move_history < depth * -2048) {
+                break;
+            }             
+        }
+
         // Do move
         Position pos_after = pos.move(m);
         moves_played++;


### PR DESCRIPTION
Elo   | 20.70 +- 9.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2924 W: 1038 L: 864 D: 1022
Penta | [103, 282, 567, 358, 152]
https://clockworkopenbench.pythonanywhere.com/test/91/

bench: 7395263