### PR TITLE
Internal Iterative Reductions / Retest without UB

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -192,8 +192,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     // Internal Iterative Reductions
     if (PV_NODE && depth >= 8 && (!tt_data || tt_data->move == Move::none())) {
         depth--;
-    }
-    
+    }    
 
     // Reuse TT score as a better positional evaluation
     auto tt_adjusted_eval = static_eval;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,6 +189,12 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     bool  is_in_check = pos.is_in_check();
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
+    // Internal Iterative Reductions
+    if (PV_NODE && depth >= 8 && (!tt_data || tt_data->move == Move::none())) {
+        depth--;
+    }
+    
+
     // Reuse TT score as a better positional evaluation
     auto tt_adjusted_eval = static_eval;
     if (tt_data && tt_data->bound != (tt_data->score > static_eval ? Bound::Upper : Bound::Lower)) {


### PR DESCRIPTION
Elo   | 42.91 +- 14.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1408 W: 571 L: 398 D: 439
Penta | [46, 117, 262, 176, 103]
https://clockworkopenbench.pythonanywhere.com/test/94/

bench: 7420203