### PR TITLE
Quiet History Pruning and Promotion Move Ordering

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -106,8 +106,10 @@ Move MovePicker::pick_next(MoveList& moves) {
 }
 
 i32 MovePicker::score_move(Move move) const {
-    if (quiet_move(move)) {
+     if (quiet_move(move)) {
         return m_history.get_quiet_stats(m_pos, move);
+    } else if (move.is_promotion()) {
+        return 500;
     } else {
         return 100 * static_cast<int>(m_pos.piece_at(move.to()))
              - static_cast<int>(m_pos.piece_at(move.from()));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -240,10 +240,17 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
         bool quiet = quiet_move(m);
 
+         auto move_history = m_td.history.get_quiet_stats(pos, m);
+
         if (!ROOT_NODE && best_value > -VALUE_WIN && quiet) {
             // Late Move Pruning (LMP)
             if (moves_played >= 4 + 3 * depth * depth) {
                 continue;
+            }
+            
+            // Quiet History Pruning
+            if (depth <= 4 && !is_in_check && move_history < depth * -2048) {
+                break;
             }
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -246,8 +246,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             // Late Move Pruning (LMP)
             if (moves_played >= 4 + 3 * depth * depth) {
                 continue;
-            }
-            
+            }            
             // Quiet History Pruning
             if (depth <= 4 && !is_in_check && move_history < depth * -2048) {
                 break;


### PR DESCRIPTION
Elo   | 5.53 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15022 W: 5001 L: 4762 D: 5259
Penta | [633, 1635, 2780, 1786, 677]
https://clockworkopenbench.pythonanywhere.com/test/98/

bench: 5246267