### PR TITLE
Add PVS SEE Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,6 +255,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             }
         }
         Value see_threshold = quiet ? -67 * depth : -32 * depth;
+        
         // SEE PVS Pruning        
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,8 +255,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             }
         }
         auto see_threshold = quiet ? -67 * depth : -32 * depth;
-        // SEE PVS Pruning
-        
+        // SEE PVS Pruning        
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -254,6 +254,12 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
                 break;
             }
         }
+        auto see_threshold = quiet ? -67 * depth : -32 * depth;
+        // SEE PVS Pruning
+        
+        if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
+            continue;
+        }
 
         // Do move
         Position pos_after = pos.move(m);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -254,9 +254,9 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
                 break;
             }
         }
+
         Value see_threshold = quiet ? -67 * depth : -32 * depth;
-        
-        // SEE PVS Pruning        
+        // SEE PVS Pruning
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -254,7 +254,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
                 break;
             }
         }
-        auto see_threshold = quiet ? -67 * depth : -32 * depth;
+        Value see_threshold = quiet ? -67 * depth : -32 * depth;
         // SEE PVS Pruning        
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;


### PR DESCRIPTION
Elo   | 24.12 +- 10.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2496 W: 915 L: 742 D: 839
Penta | [80, 259, 461, 304, 144]
https://clockworkopenbench.pythonanywhere.com/test/115/

bench: 1497824