### PR TITLE
Skip quiet moves after first quiet in QS check.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -393,6 +393,9 @@ Value Worker::quiesce(Position& pos, Stack* ss, Value alpha, Value beta, i32 ply
         Position pos_after = pos.move(m);
         moves_searched++;
 
+        // If we've found a legal move, then we can begin skipping quiet moves.
+        moves.skip_quiets();
+
         // Put hash into repetition table. TODO: encapsulate this and any other future adjustment to do "on move" into a proper function
         m_repetition_info.push(pos_after.get_hash_key(), pos_after.is_reversible(m));
 


### PR DESCRIPTION
```
Test  | skip-quiets-qs-check
Elo   | 5.85 +- 4.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14028 W: 4650 L: 4414 D: 4964
Penta | [598, 1505, 2605, 1675, 631]
https://clockworkopenbench.pythonanywhere.com/test/117/
```

Bench: 1994966