### PR TITLE
More Safe Noisy Margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,7 +255,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             }
         }
 
-        Value see_threshold = quiet ? -67 * depth : -64 * depth;        
+        Value see_threshold = quiet ? -67 * depth : -64 * depth;
         // SEE PVS Pruning
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,8 +255,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             }
         }
 
-        Value see_threshold = quiet ? -67 * depth : -64 * depth;
-        
+        Value see_threshold = quiet ? -67 * depth : -64 * depth;        
         // SEE PVS Pruning
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -256,6 +256,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         }
 
         Value see_threshold = quiet ? -67 * depth : -64 * depth;
+        
         // SEE PVS Pruning
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -255,7 +255,8 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
             }
         }
 
-        Value see_threshold = quiet ? -67 * depth : -32 * depth;
+        Value see_threshold = quiet ? -67 * depth : -64 * depth;
+        
         // SEE PVS Pruning
         if (depth <= 10 && !ROOT_NODE && !SEE::see(pos, m, see_threshold)) {
             continue;


### PR DESCRIPTION
```
Test  | more-safe-noisy-margin
Elo   | 22.06 +- 10.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2760 W: 1003 L: 828 D: 929
Penta | [109, 259, 515, 342, 155]
```
bench: 1690669