### PR TITLE
Nmp Eval Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -207,8 +207,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     }
 
     if (!PV_NODE && !is_in_check && depth >= tuned::nmp_depth && static_eval >= beta) {
-        int      R         = tuned::nmp_base_r + std::min(3, (static_eval - beta) / 300);
-        
+        int      R         = tuned::nmp_base_r + std::min(3, (static_eval - beta) / 300);        
         Position pos_after = pos.null_move();
 
         m_repetition_info.push(pos_after.get_hash_key(), true);


### PR DESCRIPTION
```
Test  | nmp-eval-reduction
Elo   | 17.42 +- 8.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3534 W: 1255 L: 1078 D: 1201
Penta | [131, 362, 653, 441, 180]
```
bench: 1553698