### PR TITLE
NMP TT Adjusted Eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -207,8 +207,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
     }
 
     if (!PV_NODE && !is_in_check && depth >= tuned::nmp_depth && tt_adjusted_eval >= beta) {
-        int      R         = tuned::nmp_base_r + std::min(3, (tt_adjusted_eval - beta) / 300);
-        
+        int      R         = tuned::nmp_base_r + std::min(3, (tt_adjusted_eval - beta) / 300);        
         Position pos_after = pos.null_move();
 
         m_repetition_info.push(pos_after.get_hash_key(), true);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -206,8 +206,9 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         return tt_adjusted_eval;
     }
 
-    if (!PV_NODE && !is_in_check && depth >= tuned::nmp_depth && static_eval >= beta) {
-        int      R         = tuned::nmp_base_r + std::min(3, (static_eval - beta) / 300);        
+    if (!PV_NODE && !is_in_check && depth >= tuned::nmp_depth && tt_adjusted_eval >= beta) {
+        int      R         = tuned::nmp_base_r + std::min(3, (tt_adjusted_eval - beta) / 300);
+        
         Position pos_after = pos.null_move();
 
         m_repetition_info.push(pos_after.get_hash_key(), true);


### PR DESCRIPTION
```
Test  | nmp-tt-adjusted-eval
Elo   | 6.39 +- 4.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12288 W: 4133 L: 3907 D: 4248
Penta | [543, 1284, 2309, 1420, 588]
```
bench: 1594820