### PR TITLE
try lva recapture of last moved before other noisy moves

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -37,7 +37,7 @@ Move MovePicker::next() {
             }
         }
 
-        [[fallthrough]]
+        [[fallthrough]];
     case Stage::GenerateMoves:
         generate_moves();
 

--- a/src/movepick.hpp
+++ b/src/movepick.hpp
@@ -17,12 +17,14 @@ public:
     explicit MovePicker(const Position& pos,
                         const History&  history,
                         Move            tt_move = Move::none(),
-                        Move            killer  = Move::none()) :
+                        Move            killer  = Move::none(),
+                        Move            last    = Move::none()) :
         m_pos(pos),
         m_history(history),
         m_movegen(pos),
         m_tt_move(tt_move),
-        m_killer(killer) {
+        m_killer(killer),
+        m_last_move(last) {
     }
 
     void skip_quiets();
@@ -36,6 +38,7 @@ public:
 private:
     enum class Stage {
         EmitTTMove,
+        LVARecapture,
         GenerateMoves,
         ScoreNoisy,
         EmitGoodNoisy,
@@ -66,6 +69,8 @@ private:
 
     Move m_tt_move;
     Move m_killer;
+    Move m_last_move;
+    Move m_lva_recapture;
 };
 
 }

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -129,6 +129,23 @@ public:
         return (attack_table(color).read(sq) >> id.raw) & 1;
     }
 
+    Square least_valuable_attacker_sq(Color attacker_color, Square sq) const {
+        u16 attackers = attack_table(attacker_color).read(sq);
+
+        PieceType min_ptype = static_cast<PieceType>(0xFF);
+        Square min_sq = Square::invalid();
+
+        for (; attackers; attackers = clear_lowest_bit(attackers)) {
+        PieceId id{static_cast<u8>(std::countr_zero(attackers))};
+        if (piece_list(attacker_color)[id] < min_ptype) {
+            min_ptype = piece_list(attacker_color)[id];
+            min_sq = piece_list_sq(attacker_color)[id];
+        }
+        }
+
+        return min_sq;
+    }
+
     [[nodiscard]] Position move(Move m) const;
     [[nodiscard]] Position null_move() const;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -229,7 +229,7 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         }
     }
 
-    MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none(), ss->killer};
+    MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none(), ss->killer, ply != 0 ? (ss - 1)->applied : Move::none()};
     Move       best_move    = Move::none();
     Value      best_value   = -VALUE_INF;
     i32        moves_played = 0;
@@ -397,6 +397,7 @@ Value Worker::quiesce(Position& pos, Stack* ss, Value alpha, Value beta, i32 ply
 
         // Do move
         Position pos_after = pos.move(m);
+        ss[ply].applied = m;
         moves_searched++;
 
         // If we've found a legal move, then we can begin skipping quiet moves.

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -13,6 +13,7 @@ namespace Search {
 struct Stack {
     Move* pv;
     Move  killer;
+    Move  applied;
 };
 
 struct SearchLimits {


### PR DESCRIPTION
This really banged in Lunar, but bench was slightly increased so maybe Clockwork's move ordering is already good enough? 

SPRT: https://clockworkopenbench.pythonanywhere.com/test/126/