### PR TITLE
Allow reduction of 1 in noisies

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -8,6 +8,7 @@
 #include "tuned.hpp"
 #include "uci.hpp"
 #include "util/types.hpp"
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <iostream>
@@ -271,10 +272,15 @@ Value Worker::search(Position& pos, Stack* ss, Value alpha, Value beta, Depth de
         // Get search value
         Depth new_depth = depth - 1 + pos_after.is_in_check();
         Value value;
-        if (depth >= 3 && moves_played >= 4 && quiet) {
+        if (depth >= 3 && moves_played >= 4) {
             i32 reduction =
               static_cast<i32>(0.77 + std::log(depth) * std::log(moves_played) / 2.36);
             reduction -= PV_NODE;
+
+            if (!quiet) {
+                reduction = std::min(reduction, 1);
+            }
+
             Depth reduced_depth = std::clamp<Depth>(new_depth - reduction, 1, new_depth);
             value = -search<false>(pos_after, ss + 1, -alpha - 1, -alpha, reduced_depth, ply + 1);
             if (value > alpha && reduced_depth < new_depth) {


### PR DESCRIPTION
```
Test  | noisy_lmr
Elo   | 5.42 +- 4.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15332 W: 5108 L: 4869 D: 5355
Penta | [621, 1712, 2838, 1797, 698]
```
https://clockworkopenbench.pythonanywhere.com/test/168/

bench: 1588311