### PR TITLE
Make null move pruning eval difference component more aggressive

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -333,7 +333,7 @@ Value Worker::search(
 
     if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
         && tt_adjusted_eval >= beta) {
-        int      R         = tuned::nmp_base_r + std::min(3, (tt_adjusted_eval - beta) / 816);
+        int      R         = tuned::nmp_base_r + std::min(3, (tt_adjusted_eval - beta) / 400);
         Position pos_after = pos.null_move();
 
         repetition_info.push(pos_after.get_hash_key(), true);


### PR DESCRIPTION
This patch stems from the addition of massive elo from psqt

```
Test  | nmpaggro
Elo   | 10.29 +- 6.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6282 W: 2225 L: 2039 D: 2018
Penta | [243, 611, 1303, 685, 299]
```
https://clockworkopenbench.pythonanywhere.com/test/184/

Bench: 1740694