### PR TITLE
Efficiently Updated PSQTs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(srcs
         src/common.hpp
         src/evaluation.cpp
         src/evaluation.hpp
+        src/eval_constants.hpp
         src/eval_types.hpp
         src/geometry.cpp
         src/geometry.hpp
@@ -76,6 +77,7 @@ set(srcs
         src/perft.hpp
         src/position.cpp
         src/position.hpp
+        src/psqt_state.hpp
         src/repetition_info.hpp
         src/repetition_info.cpp
         src/search.cpp

--- a/src/eval_constants.hpp
+++ b/src/eval_constants.hpp
@@ -1,0 +1,20 @@
+#include "eval_types.hpp"
+
+namespace Clockwork {
+
+extern const PScore PAWN_MAT;
+extern const PScore KNIGHT_MAT;
+extern const PScore BISHOP_MAT;
+extern const PScore ROOK_MAT;
+extern const PScore QUEEN_MAT;
+extern const PScore MOBILITY_VAL;
+extern const PScore TEMPO_VAL;
+
+extern const std::array<PScore, 48> PAWN_PSQT;
+extern const std::array<PScore, 64> KNIGHT_PSQT;
+extern const std::array<PScore, 64> BISHOP_PSQT;
+extern const std::array<PScore, 64> ROOK_PSQT;
+extern const std::array<PScore, 64> QUEEN_PSQT;
+extern const std::array<PScore, 64> KING_PSQT;
+
+}

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -84,7 +84,7 @@ const std::array<PScore, 64> KING_PSQT = {
 };
 // clang-format on
 
-Score evaluate_white_pov(Position pos) {
+Score evaluate_white_pov(const Position& pos) {
 
     const Color us    = pos.active_color();
     i32         phase = pos.piece_count(Color::White, PieceType::Knight)
@@ -168,6 +168,10 @@ Score evaluate_white_pov(Position pos) {
         }
     }
 
+    if (material + psqt != pos.psqt_state().score()) {
+        std::cout << material + psqt << ' ' << pos.psqt_state().score() << "WTF" << std::endl;
+    }
+
     PScore mobility = MOBILITY_VAL * mob_count;
 
     PScore tempo = (us == Color::White) ? TEMPO_VAL : -TEMPO_VAL;
@@ -179,7 +183,7 @@ Score evaluate_white_pov(Position pos) {
 #endif
 };
 
-Score evaluate_stm_pov(Position pos) {
+Score evaluate_stm_pov(const Position& pos) {
     const Color us = pos.active_color();
     return (us == Color::White) ? evaluate_white_pov(pos) : -evaluate_white_pov(pos);
 }

--- a/src/evaluation.hpp
+++ b/src/evaluation.hpp
@@ -6,20 +6,8 @@
 #include "eval_types.hpp"
 
 namespace Clockwork {
-extern const PScore PAWN_MAT;
-extern const PScore KNIGHT_MAT;
-extern const PScore BISHOP_MAT;
-extern const PScore ROOK_MAT;
-extern const PScore QUEEN_MAT;
-extern const PScore MOBILITY_VAL;
-extern const PScore TEMPO_VAL;
-Score               evaluate_white_pov(Position pos);
-Score               evaluate_stm_pov(Position pos);
 
-extern const std::array<PScore, 48> PAWN_PSQT;
-extern const std::array<PScore, 64> KNIGHT_PSQT;
-extern const std::array<PScore, 64> BISHOP_PSQT;
-extern const std::array<PScore, 64> ROOK_PSQT;
-extern const std::array<PScore, 64> QUEEN_PSQT;
-extern const std::array<PScore, 64> KING_PSQT;
+Score evaluate_white_pov(const Position& pos);
+Score evaluate_stm_pov(const Position& pos);
+
 };

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -8,6 +8,7 @@
 
 #include "board.hpp"
 #include "move.hpp"
+#include "psqt_state.hpp"
 #include "square.hpp"
 #include "util/types.hpp"
 #include "util/vec.hpp"
@@ -96,6 +97,9 @@ public:
     [[nodiscard]] HashKey get_hash_key() const {
         return m_hash_key;
     }
+    [[nodiscard]] PsqtState psqt_state() const {
+        return m_psqt_state;
+    }
 
     [[nodiscard]] Square king_sq(Color color) const {
         return piece_list_sq(color)[PieceId{0}];
@@ -179,6 +183,8 @@ private:
     Square                              m_enpassant = Square::invalid();
     std::array<RookInfo, 2>             m_rook_info;
     HashKey                             m_hash_key;
+    PsqtState                           m_psqt_state;
+
 
     void incrementally_remove_piece(bool color, PieceId id, Square sq);
     void incrementally_add_piece(bool color, Place p, Square sq);

--- a/src/psqt_state.hpp
+++ b/src/psqt_state.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "common.hpp"
+#include "eval_constants.hpp"
+#include "eval_types.hpp"
+#include "square.hpp"
+
+
+namespace Clockwork {
+
+struct PsqtState {
+public:
+    PsqtState() = default;
+
+    void add_piece(Color color, PieceType pt, Square sq) {
+        if (color == Color::White) {
+            sq = sq.flip_vertical();
+        }
+        PScore diff{};
+        switch (pt) {
+        case PieceType::Pawn:
+            diff = PAWN_MAT + PAWN_PSQT[sq.raw - 8];
+            break;
+        case PieceType::Knight:
+            diff = KNIGHT_MAT + KNIGHT_PSQT[sq.raw];
+            break;
+        case PieceType::Bishop:
+            diff = BISHOP_MAT + BISHOP_PSQT[sq.raw];
+            break;
+        case PieceType::Rook:
+            diff = ROOK_MAT + ROOK_PSQT[sq.raw];
+            break;
+        case PieceType::Queen:
+            diff = QUEEN_MAT + QUEEN_PSQT[sq.raw];
+            break;
+        case PieceType::King:
+            diff = KING_PSQT[sq.raw];
+            break;
+        default:
+            unreachable();
+            break;
+        }
+        if (color == Color::White) {
+            m_score += diff;
+        } else {
+            m_score -= diff;
+        }
+    }
+
+    void remove_piece(Color color, PieceType pt, Square sq) {
+        if (color == Color::White) {
+            sq = sq.flip_vertical();
+        }
+        PScore diff{};
+        switch (pt) {
+        case PieceType::Pawn:
+            diff = PAWN_MAT + PAWN_PSQT[sq.raw - 8];
+            break;
+        case PieceType::Knight:
+            diff = KNIGHT_MAT + KNIGHT_PSQT[sq.raw];
+            break;
+        case PieceType::Bishop:
+            diff = BISHOP_MAT + BISHOP_PSQT[sq.raw];
+            break;
+        case PieceType::Rook:
+            diff = ROOK_MAT + ROOK_PSQT[sq.raw];
+            break;
+        case PieceType::Queen:
+            diff = QUEEN_MAT + QUEEN_PSQT[sq.raw];
+            break;
+        case PieceType::King:
+            diff = KING_PSQT[sq.raw];
+            break;
+        default:
+            unreachable();
+            break;
+        }
+        if (color == Color::White) {
+            m_score -= diff;
+        } else {
+            m_score += diff;
+        }
+    }
+
+    PScore score() const {
+        return m_score;
+    }
+
+    constexpr bool operator==(const PsqtState& other) const noexcept = default;
+    constexpr bool operator!=(const PsqtState& other) const noexcept = default;
+
+private:
+    PScore m_score = PSCORE_ZERO;
+};
+
+}

--- a/src/square.hpp
+++ b/src/square.hpp
@@ -51,6 +51,10 @@ struct Square {
         return {file(), rank()};
     }
 
+    constexpr Square flip_vertical() const {
+        return Square{static_cast<u8>(raw ^ 56)};
+    }
+
     [[nodiscard]] constexpr bool is_valid() const {
         return (raw & 0x80) == 0;
     }


### PR DESCRIPTION
```
Test  | ue_psqts
Elo   | 28.04 +- 11.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2074 W: 785 L: 618 D: 671
Penta | [71, 187, 392, 278, 109]
```
https://clockworkopenbench.pythonanywhere.com/test/185/

No functional change
Bench: 1740694