### PR TITLE
Use threats to index history

### DIFF
--- a/src/history.hpp
+++ b/src/history.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "common.hpp"
 #include "position.hpp"
 
 namespace Clockwork {
 
-using MainHistory = std::array<std::array<i32, 4096>, 2>;
+using MainHistory = std::array<std::array<std::array<i32, 2>, 4096>, 2>;
 
 constexpr i32 HISTORY_MAX = 16384;
 
@@ -13,12 +14,15 @@ public:
     History() = default;
 
     i32 get_quiet_stats(const Position& pos, Move move) const {
-        return m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()];
+        auto to_attacked = pos.attack_table(Color::White).read(move.to()) != 0;
+        return m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()][to_attacked];
     }
 
     void update_quiet_stats(const Position& pos, Move move, i32 bonus) {
-        update_hist_entry(m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()],
-                          bonus);
+        auto to_attacked = pos.attack_table(Color::White).read(move.to()) != 0;
+        update_hist_entry(
+          m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()][to_attacked],
+          bonus);
     }
 
     void clear() {

--- a/src/history.hpp
+++ b/src/history.hpp
@@ -14,12 +14,12 @@ public:
     History() = default;
 
     i32 get_quiet_stats(const Position& pos, Move move) const {
-        auto to_attacked = pos.attack_table(Color::White).read(move.to()) != 0;
+        auto to_attacked = pos.attack_table(~pos.active_color()).read(move.to()) != 0;
         return m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()][to_attacked];
     }
 
     void update_quiet_stats(const Position& pos, Move move, i32 bonus) {
-        auto to_attacked = pos.attack_table(Color::White).read(move.to()) != 0;
+        auto to_attacked = pos.attack_table(~pos.active_color()).read(move.to()) != 0;
         update_hist_entry(
           m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()][to_attacked],
           bonus);


### PR DESCRIPTION
```
Test  | hist_threats
Elo   | 2.36 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 88734 W: 26952 L: 26349 D: 35433
Penta | [2930, 10328, 17391, 10645, 3073]
```
https://clockworkopenbench.pythonanywhere.com/test/190/

bench: 1499891