### PR TITLE
Make lmp even more aggressive

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -222,7 +222,8 @@ Move Worker::iterative_deepening(const Position& root_position) {
 
     for (Depth search_depth = 1; search_depth < MAX_PLY; search_depth++) {
         // Call search
-        Value score = search<IS_MAIN, true>(root_position, &ss[0], alpha, beta, search_depth, 0, false);
+        Value score =
+          search<IS_MAIN, true>(root_position, &ss[0], alpha, beta, search_depth, 0, false);
 
         // If m_stopped is true, then the search exited early. Discard the results for this depth.
         if (m_stopped) {
@@ -338,8 +339,8 @@ Value Worker::search(
 
         repetition_info.push(pos_after.get_hash_key(), true);
 
-        Value value =
-          -search<IS_MAIN, false>(pos_after, ss + 1, -beta, -beta + 1, depth - R, ply + 1, !cutnode);
+        Value value = -search<IS_MAIN, false>(pos_after, ss + 1, -beta, -beta + 1, depth - R,
+                                              ply + 1, !cutnode);
 
         repetition_info.pop();
 
@@ -373,7 +374,7 @@ Value Worker::search(
 
         if (!ROOT_NODE && best_value > -VALUE_WIN) {
             // Late Move Pruning (LMP)
-            if (moves_played >= 3 + 2 * depth * depth) {
+            if (moves_played >= 3 + depth * depth) {
                 continue;
             }
             // Quiet History Pruning
@@ -423,12 +424,13 @@ Value Worker::search(
                                                 ply + 1, !cutnode);
             }
         } else if (!PV_NODE || moves_played > 1) {
-            value =
-              -search<IS_MAIN, false>(pos_after, ss + 1, -alpha - 1, -alpha, new_depth, ply + 1, !cutnode);
+            value = -search<IS_MAIN, false>(pos_after, ss + 1, -alpha - 1, -alpha, new_depth,
+                                            ply + 1, !cutnode);
         }
 
         if (PV_NODE && (moves_played == 1 || value > alpha)) {
-            value = -search<IS_MAIN, true>(pos_after, ss + 1, -beta, -alpha, new_depth, ply + 1, false);
+            value =
+              -search<IS_MAIN, true>(pos_after, ss + 1, -beta, -alpha, new_depth, ply + 1, false);
         }
 
         // TODO: encapsulate this and any other future adjustment to do "on going back" into a proper function


### PR DESCRIPTION
```
Test  | even_more_aggro_lmp
Elo   | 14.09 +- 7.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4392 W: 1438 L: 1260 D: 1694
Penta | [142, 478, 833, 546, 197]
```
https://clockworkopenbench.pythonanywhere.com/test/202/

Bench: 1030684