### PR TITLE
Fix dimensions of history array

### DIFF
--- a/src/history.hpp
+++ b/src/history.hpp
@@ -5,7 +5,7 @@
 
 namespace Clockwork {
 
-using MainHistory = std::array<std::array<std::array<i32, 2>, 4096>, 2>;
+using MainHistory = std::array<std::array<std::array<i32, 4>, 4096>, 2>;
 
 constexpr i32 HISTORY_MAX = 16384;
 


### PR DESCRIPTION
```
Test  | hist_array_fix
Elo   | 8.66 +- 6.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 5298 W: 1673 L: 1541 D: 2084
Penta | [191, 556, 1031, 672, 199]
```
http://clockworkopenbench.pythonanywhere.com/test/216/

Bench: 9020679