### PR TITLE
Movepicker speedup

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -90,8 +90,11 @@ Move MovePicker::next() {
 emit_bad_noisy:
         [[fallthrough]];
     case Stage::EmitBadNoisy:
-        if (m_current_index < m_bad_noisy.size()) {
-            return m_bad_noisy[m_current_index++];
+        while (m_current_index < m_bad_noisy.size()) {
+            Move curr = m_bad_noisy[m_current_index++];
+            if (curr != m_tt_move && curr != m_killer) {
+                return curr;
+            }
         }
         m_stage = Stage::End;
 


### PR DESCRIPTION
Bad captures are already sorted, no need to resort them
(as an aside, the scores used for "resorting" them were the scores of the quiets from the previous stage, so they weren't actually being sorted)

Failed yellow but passes non-regression bounds
https://clockworkopenbench.pythonanywhere.com/test/217/
<img width="1007" height="546" alt="image" src="https://github.com/user-attachments/assets/6d03853a-51b1-43c9-83c4-dcb31b67fddd" />

No functional change
Bench: 9020679