### PR TITLE
Do IIR in expected cut nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -341,7 +341,7 @@ Value Worker::search(
     Value static_eval = is_in_check ? -VALUE_INF : evaluate(pos);
 
     // Internal Iterative Reductions
-    if (PV_NODE && depth >= 8 && (!tt_data || tt_data->move == Move::none())) {
+    if ((PV_NODE || cutnode) && depth >= 8 && (!tt_data || tt_data->move == Move::none())) {
         depth--;
     }
 
@@ -443,7 +443,7 @@ Value Worker::search(
             if (!quiet) {
                 reduction = std::min(reduction, 1024);
             }
-            
+
             reduction /= 1024;
 
             Depth reduced_depth = std::clamp<Depth>(new_depth - reduction, 1, new_depth);


### PR DESCRIPTION
Maybe worth trying to reduce the minimum depth of IIR
```
Test  | iir_cn
Elo   | 5.32 +- 3.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15020 W: 4691 L: 4461 D: 5868
Penta | [477, 1754, 2919, 1782, 578]
```
https://clockworkopenbench.pythonanywhere.com/test/219/

Bench: 8634354