### PR TITLE
Two-ply Continuation History

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -15,6 +15,9 @@ i32 History::get_quiet_stats(const Position& pos, Move move, i32 ply, Search::St
     if (ply >= 1 && (ss - 1)->cont_hist_entry != nullptr) {
         stats += (*(ss - 1)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
     }
+    if (ply >= 2 && (ss - 2)->cont_hist_entry != nullptr) {
+        stats += (*(ss - 2)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
+    }
 
     return stats;
 }
@@ -30,6 +33,9 @@ void History::update_quiet_stats(
     usize     pt_idx = static_cast<usize>(pt) - static_cast<usize>(PieceType::Pawn);
     if (ply >= 1 && (ss - 1)->cont_hist_entry != nullptr) {
         update_hist_entry((*(ss - 1)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], bonus);
+    }
+    if (ply >= 2 && (ss - 2)->cont_hist_entry != nullptr) {
+        update_hist_entry((*(ss - 2)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], bonus);
     }
 }
 


### PR DESCRIPTION
```
Test  | 2ply_conthist
Elo   | 7.56 +- 5.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9146 W: 2878 L: 2679 D: 3589
Penta | [301, 1019, 1778, 1130, 345]
```
https://clockworkopenbench.pythonanywhere.com/test/230/

Bench: 8824332