### PR TITLE
Soft Time Management

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -171,6 +171,8 @@ void Worker::start_searching() {
         m_search_limits = {
           .hard_time_limit = TM::compute_hard_limit(m_search_start, m_searcher.settings,
                                                     root_position.active_color()),
+          .soft_time_limit = TM::compute_soft_limit(m_search_start, m_searcher.settings,
+                                                    root_position.active_color()),
           .soft_node_limit = m_searcher.settings.soft_nodes > 0 ? m_searcher.settings.soft_nodes
                                                                 : std::numeric_limits<u64>::max(),
           .hard_node_limit = m_searcher.settings.hard_nodes > 0 ? m_searcher.settings.hard_nodes
@@ -268,7 +270,11 @@ Move Worker::iterative_deepening(const Position& root_position) {
         if (IS_MAIN && search_nodes() >= m_search_limits.soft_node_limit) {
             break;
         }
-        // TODO: add any soft time limit check here
+        time::TimePoint now = time::Clock::now();
+        // check soft time limit
+        if (IS_MAIN && now >= m_search_limits.soft_time_limit) {
+            break;
+        }
 
         if (IS_MAIN) {
             print_info_line();

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -42,6 +42,7 @@ struct Stack {
 
 struct SearchLimits {
     time::TimePoint hard_time_limit;
+    time::TimePoint soft_time_limit;
     u64             soft_node_limit;
     u64             hard_node_limit;
     Depth           depth_limit;

--- a/src/tm.cpp
+++ b/src/tm.cpp
@@ -15,9 +15,9 @@ time::TimePoint compute_hard_limit(time::TimePoint               search_start,
     if (settings.w_time >= 0) {
         const auto compute_buffer_time = [&]() -> u64 {
             if (stm == Color::White) {
-                return settings.w_time / 20 + settings.w_inc / 2;
+                return settings.w_time / 4;
             } else {
-                return settings.b_time / 20 + settings.b_inc / 2;
+                return settings.b_time / 4;
             }
         };
         hard_limit = min(hard_limit, search_start + Milliseconds(compute_buffer_time()));
@@ -28,6 +28,28 @@ time::TimePoint compute_hard_limit(time::TimePoint               search_start,
     }
 
     return hard_limit - UCI_LATENCY;
+}
+
+time::TimePoint compute_soft_limit(time::TimePoint               search_start,
+                                   const Search::SearchSettings& settings,
+                                   const Color                   stm) {
+    using namespace std;
+    using namespace time;
+
+    auto soft_limit = TimePoint::max();
+
+    if (settings.w_time >= 0) {
+        const auto compute_buffer_time = [&]() -> u64 {
+            if (stm == Color::White) {
+                return settings.w_time / 20 + settings.w_inc / 2;
+            } else {
+                return settings.b_time / 20 + settings.b_inc / 2;
+            }
+        };
+        soft_limit = min(soft_limit, search_start + Milliseconds(compute_buffer_time()));
+    }
+
+    return soft_limit;
 }
 
 }

--- a/src/tm.hpp
+++ b/src/tm.hpp
@@ -8,5 +8,8 @@ constexpr time::Milliseconds UCI_LATENCY(50);
 time::TimePoint              compute_hard_limit(time::TimePoint               search_start,
                                                 const Search::SearchSettings& settings,
                                                 const Color                   stm);
+time::TimePoint              compute_soft_limit(time::TimePoint               search_start,
+                                                const Search::SearchSettings& settings,
+                                                const Color                   stm);
 // Will add soft tm and other helper functions here
 }


### PR DESCRIPTION
Use the old hard limit (time / 20 + inc / 2) as the new soft limit and use time / 4 as the new hard limit
```
Test  | soft_tm
Elo   | 54.16 +- 14.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 970 W: 359 L: 209 D: 402
Penta | [11, 78, 194, 154, 48]
```
https://clockworkopenbench.pythonanywhere.com/test/232/

Bench: 8824332