### PR TITLE
Avoid clearing histories before every search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -159,7 +159,6 @@ void Worker::prepare() {
 }
 
 void Worker::start_searching() {
-    m_td.history.clear();
     m_td.psqt_states.reserve(MAX_PLY + 1);
     m_td.psqt_states.clear();
     m_td.psqt_states.push_back(PsqtState(root_position));


### PR DESCRIPTION
Only clear histories on ucinewgame
I expect this to scale very poorly
```
Test  | persistent_hist
Elo   | 38.14 +- 12.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1372 W: 486 L: 336 D: 550
Penta | [23, 126, 270, 212, 55]
```
https://clockworkopenbench.pythonanywhere.com/test/231/

Bench: 8080705