### PR TITLE
NMP Depth reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -364,7 +364,7 @@ Value Worker::search(
 
     if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
         && tt_adjusted_eval >= beta) {
-        int      R         = tuned::nmp_base_r + std::min(3, (tt_adjusted_eval - beta) / 400);
+        int      R = tuned::nmp_base_r + depth / 4 + std::min(3, (tt_adjusted_eval - beta) / 400);
         Position pos_after = pos.null_move();
 
         repetition_info.push(pos_after.get_hash_key(), true);


### PR DESCRIPTION
```
Test  | nmp_depth_red
Elo   | 37.77 +- 12.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1376 W: 485 L: 336 D: 555
Penta | [22, 127, 282, 194, 63]
```
https://clockworkopenbench.pythonanywhere.com/test/233/

Bench: 6854497