### PR TITLE
Use break instead of continue in LMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -405,7 +405,7 @@ Value Worker::search(
         if (!ROOT_NODE && best_value > -VALUE_WIN) {
             // Late Move Pruning (LMP)
             if (moves_played >= 3 + depth * depth) {
-                continue;
+                break;
             }
             // Quiet History Pruning
             if (depth <= 4 && !is_in_check && quiet && move_history < depth * -2048) {


### PR DESCRIPTION
```
Test  | lmp_break
Elo   | 23.81 +- 10.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 1958 W: 656 L: 522 D: 780
Penta | [47, 179, 421, 257, 75]
```
https://clockworkopenbench.pythonanywhere.com/test/235/

No functional change
Bench: 8080705