### PR TITLE
Adjust minimum LMR move count with respect to PV nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -440,7 +440,7 @@ Value Worker::search(
         // Get search value
         Depth new_depth = depth - 1 + pos_after.is_in_check();
         Value value;
-        if (depth >= 3 && moves_played >= 4) {
+        if (depth >= 3 && moves_played >= 3 + 2 * PV_NODE) {
             i32 reduction = static_cast<i32>(
               std::round(1024 * (0.77 + std::log(depth) * std::log(moves_played) / 2.36)));
             reduction -= 1024 * PV_NODE;


### PR DESCRIPTION
STC
```
Test  | less-lmr-pv
Elo   | 12.88 +- 6.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4292 W: 1337 L: 1178 D: 1777
Penta | [91, 467, 913, 542, 133]
```
https://clockworkopenbench.pythonanywhere.com/test/244/

Bench: 5785284