### PR TITLE
Non-pawn correction history.

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -56,28 +56,46 @@ void History::update_noisy_stats(const Position& pos, Move move, i32 bonus) {
                       bonus);
 }
 
-void History::update_correction_history(Color side, HashKey pawn_key, i32 depth, i32 diff) {
-    usize pawn_index  = static_cast<usize>(pawn_key % CORRECTION_HISTORY_ENTRY_NB);
-    i32&  entry       = m_corr_hist[static_cast<usize>(side)][pawn_index];
-    i32   new_weight  = std::min(16, 1 + depth);
-    i32   scaled_diff = diff * CORRECTION_HISTORY_GRAIN;
+void History::update_correction_history(const Position& pos, i32 depth, i32 diff) {
+    usize side_index     = static_cast<usize>(pos.active_color());
+    u64   pawn_key       = pos.get_pawn_key();
+    u64   non_pawn_key   = pos.get_non_pawn_key();
+    usize pawn_index     = static_cast<usize>(pawn_key % CORRECTION_HISTORY_ENTRY_NB);
+    usize non_pawn_index = static_cast<usize>(non_pawn_key % CORRECTION_HISTORY_ENTRY_NB);
 
-    i32 update = entry * (CORRECTION_HISTORY_WEIGHT_SCALE - new_weight) + scaled_diff * new_weight;
+    i32 new_weight  = std::min(16, 1 + depth);
+    i32 scaled_diff = diff * CORRECTION_HISTORY_GRAIN;
 
-    entry = std::clamp(update / CORRECTION_HISTORY_WEIGHT_SCALE, -CORRECTION_HISTORY_MAX,
-                       CORRECTION_HISTORY_MAX);
+    auto update_entry = [=](i32& entry) {
+        i32 update =
+          entry * (CORRECTION_HISTORY_WEIGHT_SCALE - new_weight) + scaled_diff * new_weight;
+
+        entry = std::clamp(update / CORRECTION_HISTORY_WEIGHT_SCALE, -CORRECTION_HISTORY_MAX,
+                           CORRECTION_HISTORY_MAX);
+    };
+
+    update_entry(m_pawn_corr_hist[side_index][pawn_index]);
+    update_entry(m_non_pawn_corr_hist[side_index][non_pawn_index]);
 }
 
-i32 History::get_correction(Color side, HashKey pawn_key) {
-    usize pawn_index = static_cast<usize>(pawn_key % CORRECTION_HISTORY_ENTRY_NB);
-    return m_corr_hist[static_cast<usize>(side)][pawn_index] / CORRECTION_HISTORY_GRAIN;
+i32 History::get_correction(const Position& pos) {
+    usize side_index     = static_cast<usize>(pos.active_color());
+    u64   pawn_key       = pos.get_pawn_key();
+    u64   non_pawn_key   = pos.get_non_pawn_key();
+    usize pawn_index     = static_cast<usize>(pawn_key % CORRECTION_HISTORY_ENTRY_NB);
+    usize non_pawn_index = static_cast<usize>(non_pawn_key % CORRECTION_HISTORY_ENTRY_NB);
+    i32   correction     = 0;
+    correction += m_pawn_corr_hist[side_index][pawn_index] / CORRECTION_HISTORY_GRAIN;
+    correction += m_non_pawn_corr_hist[side_index][non_pawn_index] / CORRECTION_HISTORY_GRAIN;
+    return correction;
 }
 
 void History::clear() {
     std::memset(&m_main_hist, 0, sizeof(MainHistory));
     std::memset(&m_cont_hist, 0, sizeof(ContHistory));
     std::memset(&m_capt_hist, 0, sizeof(CaptHistory));
-    std::memset(&m_corr_hist, 0, sizeof(CorrectionHistory));
+    std::memset(&m_pawn_corr_hist, 0, sizeof(CorrectionHistory));
+    std::memset(&m_non_pawn_corr_hist, 0, sizeof(CorrectionHistory));
 }
 
 }

--- a/src/history.hpp
+++ b/src/history.hpp
@@ -39,8 +39,8 @@ public:
     i32  get_noisy_stats(const Position& pos, Move move) const;
     void update_noisy_stats(const Position& pos, Move move, i32 bonus);
 
-    void update_correction_history(Color side, HashKey pawn_key, i32 depth, i32 diff);
-    i32  get_correction(Color side, HashKey pawn_key);
+    void update_correction_history(const Position& pos, i32 depth, i32 diff);
+    i32  get_correction(const Position& pos);
 
     void clear();
 
@@ -49,10 +49,11 @@ private:
         entry += bonus - entry * std::abs(bonus) / HISTORY_MAX;
     }
 
-    MainHistory       m_main_hist = {};
-    ContHistory       m_cont_hist = {};
-    CaptHistory       m_capt_hist = {};
-    CorrectionHistory m_corr_hist = {};
+    MainHistory       m_main_hist          = {};
+    ContHistory       m_cont_hist          = {};
+    CaptHistory       m_capt_hist          = {};
+    CorrectionHistory m_pawn_corr_hist     = {};
+    CorrectionHistory m_non_pawn_corr_hist = {};
 };
 
 }

--- a/src/history.hpp
+++ b/src/history.hpp
@@ -49,11 +49,11 @@ private:
         entry += bonus - entry * std::abs(bonus) / HISTORY_MAX;
     }
 
-    MainHistory       m_main_hist          = {};
-    ContHistory       m_cont_hist          = {};
-    CaptHistory       m_capt_hist          = {};
-    CorrectionHistory m_pawn_corr_hist     = {};
-    CorrectionHistory m_non_pawn_corr_hist = {};
+    MainHistory                      m_main_hist          = {};
+    ContHistory                      m_cont_hist          = {};
+    CaptHistory                      m_capt_hist          = {};
+    CorrectionHistory                m_pawn_corr_hist     = {};
+    std::array<CorrectionHistory, 2> m_non_pawn_corr_hist = {};
 };
 
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -23,13 +23,15 @@ void Position::incrementally_remove_piece(bool         color,
     toggle_rays(from);
 
     // TODO: check if some speed left on the table for zobrist here
-    Color     pcolor = m_board[from].color();
-    PieceType ptype  = m_board[from].ptype();
-    m_hash_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)]
-                                               [static_cast<usize>(ptype)][from.raw];
+    Color     pcolor    = m_board[from].color();
+    PieceType ptype     = m_board[from].ptype();
+    u64       piece_key = Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)]
+                                                 [static_cast<usize>(ptype)][from.raw];
+    m_hash_key ^= piece_key;
     if (ptype == PieceType::Pawn) {
-        m_pawn_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)]
-                                                   [static_cast<usize>(PieceType::Pawn)][from.raw];
+        m_pawn_key ^= piece_key;
+    } else {
+        m_non_pawn_key ^= piece_key;
     }
     updates.removes.push_back({pcolor, ptype, from});
     m_board[from] = Place::empty();
@@ -40,11 +42,13 @@ void Position::incrementally_add_piece(bool color, Place p, Square to, PsqtUpdat
     m_board[to]      = p;
     Color     pcolor = p.color();
     PieceType ptype  = p.ptype();
-    m_hash_key ^=
+    u64       piece_key =
       Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)][static_cast<usize>(ptype)][to.raw];
+    m_hash_key ^= piece_key;
     if (ptype == PieceType::Pawn) {
-        m_pawn_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)]
-                                                   [static_cast<usize>(PieceType::Pawn)][to.raw];
+        m_pawn_key ^= piece_key;
+    } else {
+        m_non_pawn_key ^= piece_key;
     }
     updates.adds.push_back({pcolor, ptype, to});
 
@@ -55,19 +59,25 @@ void Position::incrementally_add_piece(bool color, Place p, Square to, PsqtUpdat
 void Position::incrementally_mutate_piece(
   bool old_color, PieceId old_id, Square sq, bool new_color, Place p, PsqtUpdates& updates) {
     // TODO: check if some speed left on the table for zobrist here
-    m_hash_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
-                                               [static_cast<usize>(m_board[sq].ptype())][sq.raw];
+    u64 rem_piece_key =
+      Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
+                                   [static_cast<usize>(m_board[sq].ptype())][sq.raw];
+    m_hash_key ^= rem_piece_key;
     if (m_board[sq].ptype() == PieceType::Pawn) {
-        m_pawn_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
-                                                   [static_cast<usize>(PieceType::Pawn)][sq.raw];
+        m_pawn_key ^= rem_piece_key;
+    } else {
+        m_non_pawn_key ^= rem_piece_key;
     }
     updates.removes.push_back({m_board[sq].color(), m_board[sq].ptype(), sq});
     m_board[sq] = p;
-    m_hash_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
-                                               [static_cast<usize>(m_board[sq].ptype())][sq.raw];
+    u64 add_piece_key =
+      Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
+                                   [static_cast<usize>(m_board[sq].ptype())][sq.raw];
+    m_hash_key ^= add_piece_key;
     if (m_board[sq].ptype() == PieceType::Pawn) {
-        m_pawn_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
-                                                   [static_cast<usize>(PieceType::Pawn)][sq.raw];
+        m_pawn_key ^= add_piece_key;
+    } else {
+        m_non_pawn_key ^= add_piece_key;
     }
     updates.adds.push_back({p.color(), p.ptype(), sq});
 
@@ -84,21 +94,26 @@ void Position::incrementally_move_piece(
     v512 src_ray_places                  = v512::permute8(src_ray_coords, m_board.to_vec());
 
     // TODO: check if some speed left on the table for zobrist here
-    m_hash_key ^=
+    u64 rem_piece_key =
       Zobrist::piece_square_zobrist[static_cast<usize>(m_board[from].color())]
                                    [static_cast<usize>(m_board[from].ptype())][from.raw];
+    m_hash_key ^= rem_piece_key;
     if (m_board[from].ptype() == PieceType::Pawn) {
-        m_pawn_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[from].color())]
-                                                   [static_cast<usize>(PieceType::Pawn)][from.raw];
+        m_pawn_key ^= rem_piece_key;
+    } else {
+        m_non_pawn_key ^= rem_piece_key;
     }
     updates.removes.push_back({m_board[from].color(), m_board[from].ptype(), from});
     m_board[from] = Place::empty();
     m_board[to]   = p;
-    m_hash_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[to].color())]
-                                               [static_cast<usize>(m_board[to].ptype())][to.raw];
+    u64 add_piece_key =
+      Zobrist::piece_square_zobrist[static_cast<usize>(m_board[to].color())]
+                                   [static_cast<usize>(m_board[to].ptype())][to.raw];
+    m_hash_key ^= add_piece_key;
     if (m_board[to].ptype() == PieceType::Pawn) {
-        m_pawn_key ^= Zobrist::piece_square_zobrist[static_cast<usize>(m_board[to].color())]
-                                                   [static_cast<usize>(PieceType::Pawn)][to.raw];
+        m_pawn_key ^= add_piece_key;
+    } else {
+        m_non_pawn_key ^= add_piece_key;
     }
     updates.adds.push_back({p.color(), p.ptype(), to});
 
@@ -750,6 +765,7 @@ std::optional<Position> Position::parse(std::string_view board,
     result.m_attack_table = result.calc_attacks_slow();
     result.m_hash_key     = result.calc_hash_key_slow();
     result.m_pawn_key     = result.calc_pawn_key_slow();
+    result.m_non_pawn_key = result.calc_non_pawn_key_slow();
 
     return result;
 }
@@ -787,7 +803,6 @@ HashKey Position::calc_hash_key_slow() const {
 
 HashKey Position::calc_pawn_key_slow() const {
     HashKey key = 0;
-    // Iterate over all the pawns only
     for (usize sq_idx = 0; sq_idx < 64; sq_idx++) {
         Place p = m_board.mailbox[sq_idx];
         if (p.is_empty() || p.ptype() != PieceType::Pawn) {
@@ -795,6 +810,19 @@ HashKey Position::calc_pawn_key_slow() const {
         }
         key ^= Zobrist::piece_square_zobrist[static_cast<usize>(p.color())]
                                             [static_cast<usize>(PieceType::Pawn)][sq_idx];
+    }
+    return key;
+}
+
+HashKey Position::calc_non_pawn_key_slow() const {
+    HashKey key = 0;
+    for (usize sq_idx = 0; sq_idx < 64; sq_idx++) {
+        Place p = m_board.mailbox[sq_idx];
+        if (p.is_empty() || p.ptype() == PieceType::Pawn) {
+            continue;
+        }
+        key ^= Zobrist::piece_square_zobrist[static_cast<usize>(p.color())]
+                                            [static_cast<usize>(p.ptype())][sq_idx];
     }
     return key;
 }

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -102,6 +102,9 @@ public:
     [[nodiscard]] HashKey get_pawn_key() const {
         return m_pawn_key;
     }
+    [[nodiscard]] HashKey get_non_pawn_key() const {
+        return m_non_pawn_key;
+    }
 
     [[nodiscard]] Square king_sq(Color color) const {
         return piece_list_sq(color)[PieceId{0}];
@@ -174,6 +177,7 @@ public:
 
     [[nodiscard]] HashKey calc_hash_key_slow() const;
     [[nodiscard]] HashKey calc_pawn_key_slow() const;
+    [[nodiscard]] HashKey calc_non_pawn_key_slow() const;
 
     static std::optional<Position> parse(std::string_view str);
     static std::optional<Position> parse(std::string_view board,
@@ -199,6 +203,7 @@ private:
     std::array<RookInfo, 2>             m_rook_info;
     HashKey                             m_hash_key;
     HashKey                             m_pawn_key;
+    HashKey                             m_non_pawn_key;
 
 
     void incrementally_remove_piece(bool color, PieceId id, Square sq, PsqtUpdates& updates);

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -102,8 +102,8 @@ public:
     [[nodiscard]] HashKey get_pawn_key() const {
         return m_pawn_key;
     }
-    [[nodiscard]] HashKey get_non_pawn_key() const {
-        return m_non_pawn_key;
+    [[nodiscard]] HashKey get_non_pawn_key(Color color) const {
+        return m_non_pawn_key[static_cast<usize>(color)];
     }
 
     [[nodiscard]] Square king_sq(Color color) const {
@@ -175,9 +175,9 @@ public:
     const std::array<Wordboard, 2> calc_attacks_slow();
     const std::array<u16, 2>       calc_attacks_slow(Square sq);
 
-    [[nodiscard]] HashKey calc_hash_key_slow() const;
-    [[nodiscard]] HashKey calc_pawn_key_slow() const;
-    [[nodiscard]] HashKey calc_non_pawn_key_slow() const;
+    [[nodiscard]] HashKey                calc_hash_key_slow() const;
+    [[nodiscard]] HashKey                calc_pawn_key_slow() const;
+    [[nodiscard]] std::array<HashKey, 2> calc_non_pawn_key_slow() const;
 
     static std::optional<Position> parse(std::string_view str);
     static std::optional<Position> parse(std::string_view board,
@@ -203,7 +203,7 @@ private:
     std::array<RookInfo, 2>             m_rook_info;
     HashKey                             m_hash_key;
     HashKey                             m_pawn_key;
-    HashKey                             m_non_pawn_key;
+    std::array<HashKey, 2>              m_non_pawn_key;
 
 
     void incrementally_remove_piece(bool color, PieceId id, Square sq, PsqtUpdates& updates);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,4 +1,5 @@
 #include "search.hpp"
+
 #include "board.hpp"
 #include "common.hpp"
 #include "evaluation.hpp"
@@ -347,7 +348,7 @@ Value Worker::search(
     Value raw_eval    = -VALUE_INF;
     Value static_eval = -VALUE_INF;
     if (!is_in_check) {
-        correction  = m_td.history.get_correction(pos.active_color(), pos.get_pawn_key());
+        correction  = m_td.history.get_correction(pos);
         raw_eval    = is_in_check ? -VALUE_INF : evaluate(pos);
         static_eval = raw_eval + correction;
     }
@@ -548,8 +549,7 @@ Value Worker::search(
         && !(best_move != Move::none() && (best_move.is_capture() || best_move.is_promotion()))
         && !((bound == Bound::Lower && best_value <= static_eval)
              || (bound == Bound::Upper && best_value >= static_eval))) {
-        m_td.history.update_correction_history(pos.active_color(), pos.get_pawn_key(), depth,
-                                               best_value - raw_eval);
+        m_td.history.update_correction_history(pos, depth, best_value - raw_eval);
     }
 
     return best_value;
@@ -598,7 +598,7 @@ Value Worker::quiesce(const Position& pos, Stack* ss, Value alpha, Value beta, i
     Value raw_eval    = -VALUE_INF;
     Value static_eval = -VALUE_INF;
     if (!is_in_check) {
-        correction  = m_td.history.get_correction(pos.active_color(), pos.get_pawn_key());
+        correction  = m_td.history.get_correction(pos);
         raw_eval    = is_in_check ? -VALUE_INF : evaluate(pos);
         static_eval = raw_eval + correction;
     }


### PR DESCRIPTION
```
Test  | nonpawn-corrhist
Elo   | 42.91 +- 13.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1180 W: 398 L: 253 D: 529
Penta | [14, 108, 244, 167, 57]
```
https://clockworkopenbench.pythonanywhere.com/test/258/