### PR TITLE
Add insufficient material detection (exclude KBB with same colored bishops since its rare)

### DIFF
--- a/src/position.hpp
+++ b/src/position.hpp
@@ -134,6 +134,10 @@ public:
         return std::popcount(piece_list(color).mask_eq(ptype));
     }
 
+    [[nodiscard]] i16 get_piece_mask(Color color, PieceType ptype) const {
+        return piece_list(color).mask_eq(ptype);
+    }
+
     [[nodiscard]] bool is_square_attacked_by(Square sq, Color color, PieceType ptype) const {
         return attack_table(color).read(sq) & piece_list(color).mask_eq(ptype);
     }
@@ -153,6 +157,37 @@ public:
             }
         }
         return true;
+    }
+
+    [[nodiscard]] bool is_insufficient_material() const {
+        auto wpcnt = piece_count(Color::White);
+        auto bpcnt = piece_count(Color::Black);
+        switch (wpcnt + bpcnt) {
+            case 2:
+                return true;
+            case 3:
+                if ( get_piece_mask(Color::White, PieceType::Pawn)
+                    || get_piece_mask(Color::Black, PieceType::Pawn)
+                    || get_piece_mask(Color::White, PieceType::Rook)
+                    || get_piece_mask(Color::Black, PieceType::Rook)
+                    || get_piece_mask(Color::White, PieceType::Queen)
+                    || get_piece_mask(Color::Black, PieceType::Queen)) {
+                    return false;
+                }
+                return true;
+            case 4:
+                if (get_piece_mask(Color::White, PieceType::Pawn)
+                    || get_piece_mask(Color::Black, PieceType::Pawn)
+                    || get_piece_mask(Color::White, PieceType::Rook)
+                    || get_piece_mask(Color::Black, PieceType::Rook)
+                    || get_piece_mask(Color::White, PieceType::Queen)
+                    || get_piece_mask(Color::Black, PieceType::Queen)) {
+                    return false;
+                }
+                return false;
+            default:
+               return false;
+        }
     }
 
     template<bool UPDATE_PSQT>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -328,6 +328,10 @@ Value Worker::search(
         if (pos.get_50mr_counter() >= 100) {
             return 0;
         }
+        // Insufficient material check
+        if (pos.is_insufficient_material()){
+            return 0;
+        }
     }
 
     // Return eval if we exceed the max ply.


### PR DESCRIPTION
Passed STC

```
Test  | insufficientmat
Elo   | 3.68 +- 2.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19546 W: 5650 L: 5443 D: 8453
Penta | [329, 1971, 4995, 2120, 358]
```
https://clockworkopenbench.pythonanywhere.com/test/264/

Passed STC Endgames.epd

```
Test  | insufficientmat
Elo   | 4.96 +- 3.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8270 W: 1771 L: 1653 D: 4846
Penta | [16, 664, 2659, 778, 18]
```
https://clockworkopenbench.pythonanywhere.com/test/265/

Bench: 5331994