### PR TITLE
Fail high count LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -407,6 +407,8 @@ Value Worker::search(
 
     // Clear child's killer move.
     (ss + 1)->killer = Move::none();
+    // Clear child's fail high count
+    (ss + 1)->fail_high_count = 0;
 
     // Iterate over the move list
     for (Move m = moves.next(); m != Move::none(); m = moves.next()) {
@@ -453,6 +455,10 @@ Value Worker::search(
             }
 
             if (tt_data && tt_data->move.is_capture()) {
+                reduction += 1024;
+            }
+
+            if ((ss + 1)->fail_high_count > 3) {
                 reduction += 1024;
             }
 
@@ -503,6 +509,7 @@ Value Worker::search(
                 best_move = m;
 
                 if (value >= beta) {
+                    ss->fail_high_count++;
                     break;
                 }
             }

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -38,6 +38,7 @@ struct Stack {
     Move*          pv;
     Move           killer;
     ContHistEntry* cont_hist_entry;
+    int            fail_high_count;
 };
 
 struct SearchLimits {


### PR DESCRIPTION
```
Test  | fail-high-lmr
Elo   | 16.01 +- 7.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3388 W: 1046 L: 890 D: 1452
Penta | [59, 375, 719, 433, 108]
```
https://clockworkopenbench.pythonanywhere.com/test/261/