### PR TITLE
Forward Futility Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -421,6 +421,14 @@ Value Worker::search(
             if (moves_played >= 3 + depth * depth) {
                 break;
             }
+
+            // Forward Futility Pruning
+            Value futility = static_eval + 500 + 100 * depth;
+            if (quiet && !is_in_check && depth <= 8 && futility <= alpha) {
+                moves.skip_quiets();
+                continue;
+            }
+
             // Quiet History Pruning
             if (depth <= 4 && !is_in_check && quiet && move_history < depth * -2048) {
                 break;


### PR DESCRIPTION
```
Test  | forward-fp
Elo   | 18.88 +- 8.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2800 W: 870 L: 718 D: 1212
Penta | [56, 296, 573, 390, 85]
```
https://clockworkopenbench.pythonanywhere.com/test/273/