### PR TITLE
Four-ply Continuation History

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -18,6 +18,9 @@ i32 History::get_quiet_stats(const Position& pos, Move move, i32 ply, Search::St
     if (ply >= 2 && (ss - 2)->cont_hist_entry != nullptr) {
         stats += (*(ss - 2)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
     }
+    if (ply >= 4 && (ss - 4)->cont_hist_entry != nullptr) {
+        stats += (*(ss - 4)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
+    }
 
     return stats;
 }
@@ -36,6 +39,9 @@ void History::update_quiet_stats(
     }
     if (ply >= 2 && (ss - 2)->cont_hist_entry != nullptr) {
         update_hist_entry((*(ss - 2)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], bonus);
+    }
+    if (ply >= 4 && (ss - 4)->cont_hist_entry != nullptr) {
+        update_hist_entry((*(ss - 4)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], bonus);
     }
 }
 


### PR DESCRIPTION
```
Test  | 4ply_conthist
Elo   | 5.08 +- 3.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12938 W: 3134 L: 2945 D: 6859
Penta | [185, 1537, 2888, 1622, 237]
```
https://clockworkopenbench.pythonanywhere.com/test/286/

Bench: 2586635