### PR TITLE
Make capture SEE pruning formula quadratic

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -438,7 +438,7 @@ Value Worker::search(
                 break;
             }
 
-            Value see_threshold = quiet ? -67 * depth : -64 * depth;
+            Value see_threshold = quiet ? -67 * depth : -22 * depth * depth;
             // SEE PVS Pruning
             if (depth <= 10 && !SEE::see(pos, m, see_threshold)) {
                 continue;


### PR DESCRIPTION
```
Test  | quad-capt-see
Elo   | 2.64 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 39698 W: 9547 L: 9245 D: 20906
Penta | [625, 4699, 8947, 4905, 673]
```
https://clockworkopenbench.pythonanywhere.com/test/282/

Bench: 2698139