### PR TITLE
Use proportion of nodes spent on best move to adjust tm

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -227,6 +227,8 @@ Move Worker::iterative_deepening(const Position& root_position) {
                   << " pv " << last_best_move << std::endl;
     };
 
+    m_node_counts.fill(0);
+
     for (Depth search_depth = 1; search_depth < MAX_PLY; search_depth++) {
         // Call search
         Value alpha = -VALUE_INF, beta = VALUE_INF;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -275,8 +275,7 @@ Move Worker::iterative_deepening(const Position& root_position) {
         const auto best_move_nodes = m_node_counts[last_best_move.from_to()];
         const auto best_move_fraction =
           static_cast<double>(best_move_nodes) / static_cast<double>(total_nodes);
-        const auto percent_not_best = 1 - best_move_fraction;
-        const auto adjustment = std::max<double>(0.5, 1.5 - best_move_fraction);
+        const auto adjustment = std::max<double>(0.5, 1.5 - best_move_fraction * 2.0);
 
         // Check soft node limit
         if (IS_MAIN && search_nodes() >= m_search_limits.soft_node_limit * adjustment) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -271,19 +271,20 @@ Move Worker::iterative_deepening(const Position& root_position) {
             break;
         }
 
+        // Check soft node limit
+        if (IS_MAIN && search_nodes() >= m_search_limits.soft_node_limit) {
+            break;
+        }
+
         const auto total_nodes = std::reduce(std::begin(m_node_counts), std::end(m_node_counts), 0);
         const auto best_move_nodes = m_node_counts[last_best_move.from_to()];
         const auto best_move_fraction =
           static_cast<double>(best_move_nodes) / static_cast<double>(total_nodes);
         const auto adjustment = std::max<double>(0.5, 1.5 - best_move_fraction * 2.0);
 
-        // Check soft node limit
-        if (IS_MAIN && search_nodes() >= m_search_limits.soft_node_limit * adjustment) {
-            break;
-        }
         time::TimePoint now = time::Clock::now();
         // check soft time limit
-        if (IS_MAIN && now >= m_search_limits.soft_time_limit) {
+        if (IS_MAIN && now - m_search_start >= m_search_limits.soft_time_limit * adjustment) {
             break;
         }
 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -133,15 +133,16 @@ private:
         m_search_nodes.fetch_add(1, std::memory_order_relaxed);
     }
 
-    std::atomic<u64>  m_search_nodes;
-    time::TimePoint   m_search_start;
-    Searcher&         m_searcher;
-    std::thread       m_thread;
-    ThreadType        m_thread_type;
-    SearchLimits      m_search_limits;
-    ThreadData        m_td;
-    std::atomic<bool> m_stopped;
-    std::atomic<bool> m_exiting;
+    std::atomic<u64>         m_search_nodes;
+    time::TimePoint          m_search_start;
+    Searcher&                m_searcher;
+    std::thread              m_thread;
+    ThreadType               m_thread_type;
+    SearchLimits             m_search_limits;
+    ThreadData               m_td;
+    std::atomic<bool>        m_stopped;
+    std::atomic<bool>        m_exiting;
+    std::array<u64, 64 * 64> m_node_counts;
 
     template<bool IS_MAIN>
     Move iterative_deepening(const Position& root_position);

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -44,7 +44,7 @@ struct Stack {
 
 struct SearchLimits {
     time::TimePoint hard_time_limit;
-    time::TimePoint soft_time_limit;
+    time::Duration  soft_time_limit;
     u64             soft_node_limit;
     u64             hard_node_limit;
     Depth           depth_limit;

--- a/src/tm.cpp
+++ b/src/tm.cpp
@@ -30,13 +30,13 @@ time::TimePoint compute_hard_limit(time::TimePoint               search_start,
     return hard_limit - UCI_LATENCY;
 }
 
-time::TimePoint compute_soft_limit(time::TimePoint               search_start,
+time::Duration compute_soft_limit(time::TimePoint               search_start,
                                    const Search::SearchSettings& settings,
                                    const Color                   stm) {
     using namespace std;
     using namespace time;
 
-    auto soft_limit = TimePoint::max();
+    auto soft_limit = Duration::max();
 
     if (settings.w_time >= 0) {
         const auto compute_buffer_time = [&]() -> u64 {
@@ -46,7 +46,7 @@ time::TimePoint compute_soft_limit(time::TimePoint               search_start,
                 return settings.b_time / 20 + settings.b_inc / 2;
             }
         };
-        soft_limit = min(soft_limit, search_start + Milliseconds(compute_buffer_time()));
+        soft_limit = Milliseconds(compute_buffer_time());
     }
 
     return soft_limit;

--- a/src/tm.hpp
+++ b/src/tm.hpp
@@ -8,7 +8,7 @@ constexpr time::Milliseconds UCI_LATENCY(50);
 time::TimePoint              compute_hard_limit(time::TimePoint               search_start,
                                                 const Search::SearchSettings& settings,
                                                 const Color                   stm);
-time::TimePoint              compute_soft_limit(time::TimePoint               search_start,
+time::Duration               compute_soft_limit(time::TimePoint               search_start,
                                                 const Search::SearchSettings& settings,
                                                 const Color                   stm);
 // Will add soft tm and other helper functions here


### PR DESCRIPTION
```
Test  | nodetm
Elo   | 10.26 +- 5.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5012 W: 1218 L: 1070 D: 2724
Penta | [55, 586, 1106, 674, 85]
```
https://clockworkopenbench.pythonanywhere.com/test/295/
Bench: 2698139