### PR TITLE
Adjust node tm params

### DIFF
--- a/src/tm.cpp
+++ b/src/tm.cpp
@@ -56,7 +56,7 @@ time::TimePoint compute_soft_limit(time::TimePoint               search_start,
             if constexpr (!ADJUST_FOR_NODES_TM) {
                 return 1.0;
             }
-            return std::max<f64>(0.5, 1.5 - nodes_tm_fraction * 2.0);
+            return std::max<f64>(0.5, 1.5 - nodes_tm_fraction * (50.0 / 54.038));
         };
 
         soft_limit = min(soft_limit, search_start + Milliseconds(static_cast<i64>(compute_buffer_time() * compute_nodestm_factor())));


### PR DESCRIPTION
```
Test  | nodestm2
Elo   | 7.16 +- 4.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7762 W: 1917 L: 1757 D: 4088
Penta | [120, 870, 1759, 994, 138]
```
https://clockworkopenbench.pythonanywhere.com/test/299/

Bench: 2698139