### PR TITLE
Tweak nodestm

### DIFF
--- a/src/tm.cpp
+++ b/src/tm.cpp
@@ -56,7 +56,7 @@ time::TimePoint compute_soft_limit(time::TimePoint               search_start,
             if constexpr (!ADJUST_FOR_NODES_TM) {
                 return 1.0;
             }
-            return std::max<f64>(0.5, 1.5 - nodes_tm_fraction * (50.0 / 54.038));
+            return std::max<f64>(0.5, 2.0 - nodes_tm_fraction * (100.0 / 54.038));
         };
 
         soft_limit = min(soft_limit, search_start + Milliseconds(static_cast<i64>(compute_buffer_time() * compute_nodestm_factor())));


### PR DESCRIPTION
```
Test  | nodestm3
Elo   | 4.90 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.20 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13608 W: 3285 L: 3093 D: 7230
Penta | [195, 1548, 3146, 1700, 215]
```
https://clockworkopenbench.pythonanywhere.com/test/300/

Bench: 2698139