### PR TITLE
Reduce depth of null move search if we are improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -399,7 +399,7 @@ Value Worker::search(
 
     if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
         && tt_adjusted_eval >= beta) {
-        int      R = tuned::nmp_base_r + depth / 4 + std::min(3, (tt_adjusted_eval - beta) / 400);
+        int      R = tuned::nmp_base_r + depth / 4 + std::min(3, (tt_adjusted_eval - beta) / 400) + improving;
         Position pos_after = pos.null_move();
 
         repetition_info.push(pos_after.get_hash_key(), true);


### PR DESCRIPTION
```
Test  | improvingnmp
Elo   | 4.52 +- 3.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14904 W: 3585 L: 3391 D: 7928
Penta | [223, 1750, 3358, 1852, 269]
```
https://clockworkopenbench.pythonanywhere.com/test/313/

Bench: 2659718