### PR TITLE
Start lmr-ing one move before

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -478,7 +478,7 @@ Value Worker::search(
         // Get search value
         Depth new_depth = depth - 1 + pos_after.is_in_check();
         Value value;
-        if (depth >= 3 && moves_played >= 3 + 2 * PV_NODE) {
+        if (depth >= 3 && moves_played >= 2 + 2 * PV_NODE) {
             i32 reduction = static_cast<i32>(
               std::round(1024 * (0.77 + std::log(depth) * std::log(moves_played) / 2.36)));
             reduction -= 1024 * PV_NODE;


### PR DESCRIPTION
```
Test  | moreaggrolmr
Elo   | 2.78 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 33860 W: 8007 L: 7736 D: 18117
Penta | [469, 4062, 7670, 4187, 542]
```
https://clockworkopenbench.pythonanywhere.com/test/311/

Bench: 2388936