### PR TITLE
LMR quiet: add extra unconditional reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -496,7 +496,7 @@ Value Worker::search(
             }
 
             if (quiet) {
-                reduction -= move_history / 8;
+                reduction += (1024 - move_history / 8);
             }
 
             if (!quiet) {


### PR DESCRIPTION
Add a 1024 reduction to all LMR quiet moves.

```
Test  | lmr-quiet
Elo   | 17.59 +- 7.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2748 W: 701 L: 562 D: 1485
Penta | [40, 273, 624, 382, 55]
```
https://clockworkopenbench.pythonanywhere.com/test/323/

Bench: 1519393