### PR TITLE
Alpha raise LMR reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -428,6 +428,7 @@ Value Worker::search(
     i32        moves_played = 0;
     MoveList   quiets_played;
     MoveList   noisies_played;
+    i32        alpha_raises = 0;
 
     // Clear child's killer move.
     (ss + 1)->killer = Move::none();
@@ -482,6 +483,8 @@ Value Worker::search(
             i32 reduction = static_cast<i32>(
               std::round(1024 * (0.77 + std::log(depth) * std::log(moves_played) / 2.36)));
             reduction -= 1024 * PV_NODE;
+
+            reduction += alpha_raises * 512;
 
             if (cutnode) {
                 reduction += 1024;
@@ -544,6 +547,7 @@ Value Worker::search(
             if (value > alpha) {
                 alpha     = value;
                 best_move = m;
+                alpha_raises++;
 
                 if (value >= beta) {
                     ss->fail_high_count++;


### PR DESCRIPTION
Alpha raise reductions that reduce `depth` directly have been shown to be antiscalar.
We instead choose to do a LMR reduction dependent on the number of alpha raises seen, which may be less likely to have scaling issues.

Passed STC:
```
Elo   | 2.41 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 44476 W: 9727 L: 9419 D: 25330
Penta | [537, 5215, 10471, 5433, 582]
```

Passed LTC:
```
Elo   | 3.70 +- 2.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16736 W: 3445 L: 3267 D: 10024
Penta | [127, 1862, 4242, 1980, 157]
```

Bench: 1412936
