### PR TITLE
Count pieces corretly (Fix PieceList::mask_eq<>)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ else()
         add_test(${name} ${name})
     endfunction()
 
+    do_test(test_piece_count)
     do_test(test_see)
     do_test(test_see_prototype)
     do_test(test_is_legal)

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -46,7 +46,7 @@ struct alignas(16) PieceList {
         constexpr u8 bits = (0 | ... | (1 << static_cast<u8>(ptype)));
         const v128 to_bits{std::array<u8, 16>{0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0, 0,
                                               0, 0, 0, 0, 0, 0}};
-        return PieceMask{v128::eq8(v128::permute8(to_vec(), to_bits), v128::broadcast8(bits))};
+        return PieceMask{(v128::permute8(to_vec(), to_bits) & v128::broadcast8(bits)).nonzero8()};
     }
 
     constexpr bool operator==(const PieceList& other) const {

--- a/src/util/vec/avx2.hpp
+++ b/src/util/vec/avx2.hpp
@@ -84,6 +84,16 @@ struct v128 {
         return neq8(*this, zero());
     }
 
+    friend forceinline v128 operator&(v128 a, v128 b) {
+        return {_mm_and_si128(a.raw, b.raw)};
+    }
+    friend forceinline v128 operator|(v128 a, v128 b) {
+        return {_mm_or_si128(a.raw, b.raw)};
+    }
+    friend forceinline v128 operator^(v128 a, v128 b) {
+        return {_mm_xor_si128(a.raw, b.raw)};
+    }
+
     [[nodiscard]] forceinline bool operator==(const v128& other) const {
         __m128i t = _mm_xor_si128(raw, other.raw);
         return _mm_testz_si128(t, t);

--- a/tests/test_piece_count.cpp
+++ b/tests/test_piece_count.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <sstream>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+#include "position.hpp"
+#include "test.hpp"
+
+using namespace Clockwork;
+
+int main() {
+    Position pos = Position::parse("8/3k4/2R5/2n1r3/8/5K2/8/8 w - - 0 96").value();
+
+    REQUIRE(pos.piece_count(Color::White, PieceType::Pawn) == 0);
+    REQUIRE(pos.piece_count(Color::Black, PieceType::Pawn) == 0);
+    REQUIRE(pos.piece_count(Color::White, PieceType::Queen) == 0);
+    REQUIRE(pos.piece_count(Color::Black, PieceType::Queen) == 0);
+    REQUIRE(pos.piece_count(Color::White, PieceType::Rook) == 1);
+    REQUIRE(pos.piece_count(Color::Black, PieceType::Rook) == 1);
+    REQUIRE(pos.piece_count(Color::White, PieceType::Knight) == 0);
+    REQUIRE(pos.piece_count(Color::Black, PieceType::Knight) == 1);
+    REQUIRE(pos.piece_count(Color::White, PieceType::King) == 1);
+    REQUIRE(pos.piece_count(Color::Black, PieceType::King) == 1);
+
+    REQUIRE(pos.piece_count<PieceType::Pawn>(Color::White) == 0);
+    REQUIRE(pos.piece_count<PieceType::Pawn>(Color::Black) == 0);
+    REQUIRE(pos.piece_count<PieceType::Queen>(Color::White) == 0);
+    REQUIRE(pos.piece_count<PieceType::Queen>(Color::Black) == 0);
+    REQUIRE(pos.piece_count<PieceType::Rook>(Color::White) == 1);
+    REQUIRE(pos.piece_count<PieceType::Rook>(Color::Black) == 1);
+    REQUIRE(pos.piece_count<PieceType::Knight>(Color::White) == 0);
+    REQUIRE(pos.piece_count<PieceType::Knight>(Color::Black) == 1);
+    REQUIRE(pos.piece_count<PieceType::King>(Color::White) == 1);
+    REQUIRE(pos.piece_count<PieceType::King>(Color::Black) == 1);
+
+    REQUIRE(
+      (pos.piece_count<PieceType::Pawn, PieceType::Rook, PieceType::Queen>(Color::White) == 1));
+    REQUIRE(
+      (pos.piece_count<PieceType::Pawn, PieceType::Rook, PieceType::Queen>(Color::Black) == 1));
+
+    return 0;
+}


### PR DESCRIPTION
Bug fix.

```
Elo   | 35.16 +- 11.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 1170 W: 405 L: 287 D: 478
Penta | [8, 90, 294, 162, 31]
```

Bench: 1412936