### PR TITLE
Allow more LMR for captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,7 +503,7 @@ Value Worker::search(
             }
 
             if (!quiet) {
-                reduction = std::min(reduction, 1024);
+                reduction = std::min(reduction, 2048);
             }
 
             reduction /= 1024;


### PR DESCRIPTION
```
Test  | more-capt-lmr
Elo   | 3.57 +- 2.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22084 W: 5767 L: 5540 D: 10777
Penta | [391, 2570, 4920, 2743, 418]
```
https://clockworkopenbench.pythonanywhere.com/test/349/

Bench: 1461245