### PR TITLE
Store TT move if available when failing low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -600,10 +600,11 @@ Value Worker::search(
         }
     }
 
-    Bound bound = best_value >= beta        ? Bound::Lower
-                : best_move != Move::none() ? Bound::Exact
-                                            : Bound::Upper;
-    m_searcher.tt.store(pos, ply, best_move, best_value, depth, bound);
+    Bound bound   = best_value >= beta        ? Bound::Lower
+                  : best_move != Move::none() ? Bound::Exact
+                                              : Bound::Upper;
+    Move  tt_move = best_move != Move::none() ? best_move : tt_data ? tt_data->move : Move::none();
+    m_searcher.tt.store(pos, ply, tt_move, best_value, depth, bound);
 
     // Update to correction history.
     if (!is_in_check


### PR DESCRIPTION
```
Test  | store-tt-move
Elo   | 41.65 +- 12.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1232 W: 407 L: 260 D: 565
Penta | [15, 109, 250, 198, 44]
```
https://clockworkopenbench.pythonanywhere.com/test/449/

Bench: 8672707