### PR TITLE
Store evaluation in TT

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -64,7 +64,8 @@ std::optional<TTData> TT::probe(const Position& pos, i32 ply) const {
     size_t      idx   = mulhi64(pos.get_hash_key(), m_size);
     const auto& entry = m_entries[idx];
     if (entry.key16 == shrink_key(pos.get_hash_key())) {
-        TTData data = {.move  = entry.move,
+        TTData data = {.eval  = entry.eval,
+                       .move  = entry.move,
                        .score = score_from_tt(entry.score, ply),
                        .depth = static_cast<Depth>(entry.depth),
                        .bound = entry.bound};
@@ -73,12 +74,14 @@ std::optional<TTData> TT::probe(const Position& pos, i32 ply) const {
     return {};
 }
 
-void TT::store(const Position& pos, i32 ply, Move move, Value score, Depth depth, Bound bound) {
+void TT::store(
+  const Position& pos, i32 ply, Value eval, Move move, Value score, Depth depth, Bound bound) {
     size_t idx   = mulhi64(pos.get_hash_key(), m_size);
     auto&  entry = m_entries[idx];
     entry.key16  = shrink_key(pos.get_hash_key());
     entry.move   = move;
     entry.score  = score_to_tt(score, ply);
+    entry.eval   = static_cast<i16>(eval);
     entry.depth  = static_cast<u8>(depth);
     entry.bound  = bound;
 }

--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -15,13 +15,15 @@ struct TTEntry {
     u16   key16;
     Move  move;
     i16   score;
+    i16   eval;
     u8    depth;
     Bound bound;
 };
 
-static_assert(sizeof(TTEntry) == 8 * sizeof(u8));
+static_assert(sizeof(TTEntry) == 10 * sizeof(u8));
 
 struct TTData {
+    Value eval;
     Move  move;
     Value score;
     Depth depth;
@@ -36,10 +38,16 @@ public:
     TT(size_t mb = DEFAULT_SIZE_MB);
     ~TT();
 
-    std::optional<TTData> probe(const Position& pos, i32 ply) const;
-    void store(const Position& pos, i32 ply, Move move, Value score, Depth depth, Bound bound);
-    void resize(size_t mb);
-    void clear();
+    std::optional<TTData> probe(const Position& position, i32 ply) const;
+    void                  store(const Position& position,
+                                i32             ply,
+                                Value           eval,
+                                Move            move,
+                                Value           score,
+                                Depth           depth,
+                                Bound           bound);
+    void                  resize(size_t mb);
+    void                  clear();
 
 private:
     TTEntry* m_entries;


### PR DESCRIPTION
```
Test  | tt-eval-store
Elo   | 7.87 +- 4.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6886 W: 1762 L: 1606 D: 3518
Penta | [84, 810, 1538, 888, 123]
```
https://clockworkopenbench.pythonanywhere.com/test/452/

Bench: 9260540