### PR TITLE
feat: mate distance pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -325,6 +325,12 @@ Value Worker::search(
         return 0;
     }
 
+    alpha = std::max(alpha, mated_in(ply));
+    beta = std::min(beta, -mated_in(ply) + 1);
+    if (alpha >= beta) {
+        return alpha;
+    }
+
     if (depth <= 0) {
         return quiesce<IS_MAIN>(pos, ss, alpha, beta, ply);
     }


### PR DESCRIPTION
```
Test  | mdp
Elo   | 0.15 +- 2.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 31460 W: 7707 L: 7693 D: 16060
Penta | [347, 3495, 8049, 3475, 364]
```
https://clockworkopenbench.pythonanywhere.com/test/453/

Bench: 8461998