### PR TITLE
Fix mate score printing

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -214,7 +214,7 @@ Move Worker::iterative_deepening(const Position& root_position) {
         // Lambda to convert internal units score to uci score. TODO: add eval rescaling here once we get one
         auto format_score = [](Value score) {
             if (score < -VALUE_WIN && score > -VALUE_MATED) {
-                return "mate " + std::to_string(-(VALUE_MATED + score + 2) / 2);
+                return "mate " + std::to_string(-(VALUE_MATED + score + 1) / 2);
             }
             if (score > VALUE_WIN && score < VALUE_MATED) {
                 return "mate " + std::to_string((VALUE_MATED + 1 - score) / 2);


### PR DESCRIPTION
No functional change to search.

Fixes output, for example:
```
$ ./clockwork
position fen 1k6/5Q2/1K6/8/8/8/8/8 b - - 0 1
go depth 10
info depth 1 score cp -859 nodes 4 nps 28779 time 0 pv b8c8 
info depth 2 score cp -835 nodes 12 nps 68150 time 0 pv b8c8 f7b3 
info depth 3 score cp -839 nodes 60 nps 276577 time 0 pv b8c8 f7b3 c8b8 
info depth 4 score cp -835 nodes 187 nps 509260 time 0 pv b8c8 f7h5 c8d7 h5h3 d7e7 
info depth 5 score cp -876 nodes 404 nps 816461 time 0 pv b8c8 f7h5 c8d8 h5a5 d8e7 
info depth 6 score mate -2 nodes 610 nps 1020114 time 0 pv b8a8 b6c7 a8a7 f7a2 
info depth 7 score mate -2 nodes 619 nps 1023624 time 0 pv b8a8 b6c7 a8a7 f7a2 
info depth 8 score mate -2 nodes 628 nps 1030381 time 0 pv b8a8 b6c7 a8a7 f7a2 
info depth 9 score mate -2 nodes 636 nps 1035473 time 0 pv b8a8 b6c7 a8a7 f7a2 
info depth 10 score mate -1 nodes 646 nps 1035638 time 0 pv b8a8 f7e8 
bestmove b8a8
```

Bench: 8461998