### PR TITLE
Reduce more if not improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -501,6 +501,8 @@ Value Worker::search(
 
             reduction += alpha_raises * 512;
 
+            reduction += (512 * !improving);
+
             if (cutnode) {
                 reduction += 1024;
             }


### PR DESCRIPTION
```
Test  | lmr-improving
Elo   | 2.53 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 42774 W: 10703 L: 10392 D: 21679
Penta | [628, 5131, 9608, 5342, 678]
```
https://clockworkopenbench.pythonanywhere.com/test/480/