### PR TITLE
Decrease initial delta value for iterative deepening

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -233,7 +233,7 @@ Move Worker::iterative_deepening(const Position& root_position) {
     for (Depth search_depth = 1; search_depth < MAX_PLY; search_depth++) {
         // Call search
         Value alpha = -VALUE_INF, beta = VALUE_INF;
-        Value delta = 75;
+        Value delta = 50;
         if (search_depth >= 5) {
             alpha = last_search_score - delta;
             beta  = last_search_score + delta;


### PR DESCRIPTION
```
Test  | id-delta
Elo   | 7.02 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7772 W: 1999 L: 1842 D: 3931
Penta | [108, 882, 1759, 1019, 118]
```
https://clockworkopenbench.pythonanywhere.com/test/496/

Bench: 7571571