### PR TITLE
Abort tuning when datafile is not found

### DIFF
--- a/src/evaltune_main.cpp
+++ b/src/evaltune_main.cpp
@@ -34,7 +34,7 @@ int main() {
         std::ifstream fenFile(filename);
         if (!fenFile) {
             std::cerr << "Error opening " << filename << std::endl;
-            continue;  // skip to the next file
+            return 1;
         }
 
         std::string line;


### PR DESCRIPTION
Avoids tuning runs when you're tuning on partial data.

Bench: 7571571