### PR TITLE
Don't correct static score with search score from tt if it is a mate score.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -406,13 +406,13 @@ Value Worker::search(
         tt_adjusted_eval = tt_data->score;
     }
 
-    if (!PV_NODE && !is_in_check && depth <= tuned::rfp_depth
+    if (!PV_NODE && !is_in_check && abs(tt_adjusted_eval) < VALUE_WIN && depth <= tuned::rfp_depth
         && tt_adjusted_eval >= beta + tuned::rfp_margin * depth) {
         return tt_adjusted_eval;
     }
 
-    if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
-        && tt_adjusted_eval >= beta) {
+    if (!PV_NODE && !is_in_check && abs(tt_adjusted_eval) < VALUE_WIN && !pos.is_kp_endgame()
+        && depth >= tuned::nmp_depth && tt_adjusted_eval >= beta) {
         int R =
           tuned::nmp_base_r + depth / 4 + std::min(3, (tt_adjusted_eval - beta) / 400) + improving;
         Position pos_after = pos.null_move();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -401,18 +401,18 @@ Value Worker::search(
 
     // Reuse TT score as a better positional evaluation
     auto tt_adjusted_eval = ss->static_eval;
-    if (tt_data && tt_data->bound != Bound::None
+    if (tt_data && tt_data->bound != Bound::None && abs(tt_data->score) < VALUE_WIN
         && tt_data->bound != (tt_data->score > ss->static_eval ? Bound::Upper : Bound::Lower)) {
         tt_adjusted_eval = tt_data->score;
     }
 
-    if (!PV_NODE && !is_in_check && abs(tt_adjusted_eval) < VALUE_WIN && depth <= tuned::rfp_depth
+    if (!PV_NODE && !is_in_check && depth <= tuned::rfp_depth
         && tt_adjusted_eval >= beta + tuned::rfp_margin * depth) {
         return tt_adjusted_eval;
     }
 
-    if (!PV_NODE && !is_in_check && abs(tt_adjusted_eval) < VALUE_WIN && !pos.is_kp_endgame()
-        && depth >= tuned::nmp_depth && tt_adjusted_eval >= beta) {
+    if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
+        && tt_adjusted_eval >= beta) {
         int R =
           tuned::nmp_base_r + depth / 4 + std::min(3, (tt_adjusted_eval - beta) / 400) + improving;
         Position pos_after = pos.null_move();


### PR DESCRIPTION
```
Test  | guards++take2
Elo   | 2.14 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 67456 W: 16802 L: 16386 D: 34268
Penta | [951, 8150, 15171, 8444, 1012]
```
https://clockworkopenbench.pythonanywhere.com/test/498/

Bench: 8391368