### PR TITLE
Tweak movepicker's see margin using noisy stat score

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -3,12 +3,12 @@
 
 namespace Clockwork {
 
-i32 History::get_conthist(const Position &pos, Move move, i32 ply, Search::Stack *ss) const {
+i32 History::get_conthist(const Position& pos, Move move, i32 ply, Search::Stack* ss) const {
     i32 stats = 0;
 
-    usize stm_idx       = static_cast<usize>(pos.active_color());
-    PieceType pt     = pos.piece_at(move.from());
-    usize     pt_idx = static_cast<usize>(pt) - static_cast<usize>(PieceType::Pawn);
+    usize     stm_idx = static_cast<usize>(pos.active_color());
+    PieceType pt      = pos.piece_at(move.from());
+    usize     pt_idx  = static_cast<usize>(pt) - static_cast<usize>(PieceType::Pawn);
     if (ply >= 1 && (ss - 1)->cont_hist_entry != nullptr) {
         stats += (*(ss - 1)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
     }
@@ -23,9 +23,9 @@ i32 History::get_conthist(const Position &pos, Move move, i32 ply, Search::Stack
 }
 
 i32 History::get_quiet_stats(const Position& pos, Move move, i32 ply, Search::Stack* ss) const {
-    auto  to_attacked   = pos.is_square_attacked_by(move.to(), ~pos.active_color());
-    auto  from_attacked = pos.is_square_attacked_by(move.from(), ~pos.active_color());
-    i32   stats         = m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()]
+    auto to_attacked   = pos.is_square_attacked_by(move.to(), ~pos.active_color());
+    auto from_attacked = pos.is_square_attacked_by(move.from(), ~pos.active_color());
+    i32  stats         = m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()]
                            [from_attacked * 2 + to_attacked];
     stats += get_conthist(pos, move, ply, ss);
     return stats;
@@ -38,17 +38,20 @@ void History::update_quiet_stats(
     usize stm_idx       = static_cast<usize>(pos.active_color());
     update_hist_entry(m_main_hist[stm_idx][move.from_to()][from_attacked * 2 + to_attacked], bonus);
 
-    i32 conthist = get_conthist(pos, move, ply, ss);
-    PieceType pt     = pos.piece_at(move.from());
-    usize     pt_idx = static_cast<usize>(pt) - static_cast<usize>(PieceType::Pawn);
+    i32       conthist = get_conthist(pos, move, ply, ss);
+    PieceType pt       = pos.piece_at(move.from());
+    usize     pt_idx   = static_cast<usize>(pt) - static_cast<usize>(PieceType::Pawn);
     if (ply >= 1 && (ss - 1)->cont_hist_entry != nullptr) {
-        update_hist_entry_banger((*(ss - 1)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], conthist, bonus);
+        update_hist_entry_banger((*(ss - 1)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw],
+                                 conthist, bonus);
     }
     if (ply >= 2 && (ss - 2)->cont_hist_entry != nullptr) {
-        update_hist_entry_banger((*(ss - 2)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], conthist, bonus);
+        update_hist_entry_banger((*(ss - 2)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw],
+                                 conthist, bonus);
     }
     if (ply >= 4 && (ss - 4)->cont_hist_entry != nullptr) {
-        update_hist_entry_banger((*(ss - 4)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw], conthist, bonus);
+        update_hist_entry_banger((*(ss - 4)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw],
+                                 conthist, bonus);
     }
 }
 

--- a/src/movepick.hpp
+++ b/src/movepick.hpp
@@ -46,9 +46,9 @@ private:
         End,
     };
 
-    void generate_moves();
-    Move pick_next(MoveList& moves);
-    void score_moves(MoveList& moves);
+    void                 generate_moves();
+    std::pair<Move, i32> pick_next(MoveList& moves);
+    void                 score_moves(MoveList& moves);
 
     i32 score_move(Move move) const;
 

--- a/src/tuned.hpp
+++ b/src/tuned.hpp
@@ -7,20 +7,20 @@
 
 namespace Clockwork::tuned {
 
-#define CLOCKWORK_TUNABLES(TUNE, NO_TUNE)                   \
-                                                            \
-    /* RFP Values */                                        \
-    TUNE(rfp_margin, 147, 40, 160, 4, 0.002)                \
-    NO_TUNE(rfp_depth, 6, 4, 10, .5, 0.002)                 \
-                                                            \
-    /* NMP Values */                                        \
-    NO_TUNE(nmp_depth, 3, 1, 10, .5, 0.002)                 \
-    NO_TUNE(nmp_base_r, 3, 1, 10, .5, 0.002)                \
-                                                            \
-    /* SEE Values */                                        \
-    TUNE(quiesce_see_threshold, 0, -1000, 100, 20, 0.002)   \
-    TUNE(movepicker_see_margin, -107, -300, 300, 50, 0.002) \
-                                                            \
+#define CLOCKWORK_TUNABLES(TUNE, NO_TUNE)                         \
+                                                                  \
+    /* RFP Values */                                              \
+    TUNE(rfp_margin, 147, 40, 160, 4, 0.002)                      \
+    NO_TUNE(rfp_depth, 6, 4, 10, .5, 0.002)                       \
+                                                                  \
+    /* NMP Values */                                              \
+    NO_TUNE(nmp_depth, 3, 1, 10, .5, 0.002)                       \
+    NO_TUNE(nmp_base_r, 3, 1, 10, .5, 0.002)                      \
+                                                                  \
+    /* SEE Values */                                              \
+    TUNE(quiesce_see_threshold, 0, -1000, 100, 20, 0.002)         \
+    TUNE(movepicker_see_capthist_divisor, 48, 16, 192, 10, 0.002) \
+                                                                  \
     /* End of Tunables */
 
 #define DEFINE_VARIABLE(NAME, DEFAULT, ...) inline i32 NAME = DEFAULT;


### PR DESCRIPTION
```
Test  | movepickhhsee
Elo   | 4.36 +- 3.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14984 W: 3814 L: 3626 D: 7544
Penta | [204, 1764, 3395, 1898, 231]
```
https://clockworkopenbench.pythonanywhere.com/test/521/

Bench: 7561507