### PR TITLE
Use history in SEE pruning.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -477,7 +477,7 @@ Value Worker::search(
 
             Value see_threshold = quiet ? -67 * depth : -22 * depth * depth;
             // SEE PVS Pruning
-            if (depth <= 10 && !SEE::see(pos, m, see_threshold + move_history * 20 / 1024)) {
+            if (depth <= 10 && !SEE::see(pos, m, see_threshold - move_history * 20 / 1024)) {
                 continue;
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -477,7 +477,7 @@ Value Worker::search(
 
             Value see_threshold = quiet ? -67 * depth : -22 * depth * depth;
             // SEE PVS Pruning
-            if (depth <= 10 && !SEE::see(pos, m, see_threshold)) {
+            if (depth <= 10 && !SEE::see(pos, m, see_threshold + move_history * 20 / 1024)) {
                 continue;
             }
         }


### PR DESCRIPTION
```
Test  | see-pruning-history
Elo   | 7.21 +- 4.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7996 W: 2109 L: 1943 D: 3944
Penta | [101, 942, 1790, 1020, 145]
```
https://clockworkopenbench.pythonanywhere.com/test/520/
