### PR TITLE
Optimize multithreaded tuning

### DIFF
--- a/src/evaltune_main.cpp
+++ b/src/evaltune_main.cpp
@@ -29,13 +29,13 @@ int main() {
     std::vector<f64>      results;
 
     // List of files to load
-    std::vector<std::string> fenFiles = {
+    const std::vector<std::string> fenFiles = {
       "data/v2.2/filtered_data.txt",
       "data/v2.1/filtered_data.txt",
     };
 
     // Number of threads to use, default to half available
-    u32 thread_count = std::max<u32>(1, std::thread::hardware_concurrency() / 2);
+    const u32 thread_count = std::max<u32>(1, std::thread::hardware_concurrency() / 2);
 
     std::cout << "Running on " << thread_count << " threads" << std::endl;
 
@@ -92,14 +92,14 @@ int main() {
 
     using namespace Clockwork::Autograd;
 
-    ParameterCountInfo parameter_count          = Globals::get().get_parameter_counts();
-    Parameters         current_parameter_values = Graph::get().get_all_parameter_values();
+    const ParameterCountInfo parameter_count          = Globals::get().get_parameter_counts();
+    Parameters               current_parameter_values = Graph::get().get_all_parameter_values();
 
     AdamW optim(parameter_count, 10, 0.9, 0.999, 1e-8, 0.0);
 
-    i32       epochs     = 1000;
-    const f64 K          = 1.0 / 400;
-    size_t    batch_size = 16 * 16384;  // Set batch size here
+    const i32    epochs     = 1000;
+    const f64    K          = 1.0 / 400;
+    const size_t batch_size = 16 * 16384;  // Set batch size here
 
     std::mt19937 rng(std::random_device{}());  // Random number generator for shuffling
 
@@ -115,30 +115,34 @@ int main() {
 
         auto start = time::Clock::now();
 
-        for (size_t batch_idx = 0, batch_start = 0; batch_start < positions.size();
-             batch_start += batch_size, ++batch_idx) {
-            size_t batch_end          = std::min(batch_start + batch_size, positions.size());
-            size_t current_batch_size = batch_end - batch_start;
-            size_t subbatch_size      = (current_batch_size + thread_count - 1) / thread_count;
+        Parameters batch_gradients = Parameters::zeros(parameter_count);
 
-            Parameters batch_gradients = Parameters::zeros(parameter_count);
+        std::mutex   mutex;
+        std::barrier barrier{thread_count + 1};
 
-            std::mutex   mutex;
-            std::barrier barrier{thread_count + 1};
+        for (u32 thread_idx = 0; thread_idx < thread_count; thread_idx++) {
+            std::thread([&, thread_idx] {
+                Graph::get().cleanup();
 
-            for (size_t subbatch_start = batch_start; subbatch_start < batch_end;
-                 subbatch_start += subbatch_size) {
+                std::vector<ValuePtr> subbatch_outputs;
+                std::vector<f64>      subbatch_targets;
 
-                std::thread([&, subbatch_start] {
-                    size_t subbatch_end = std::min(subbatch_start + subbatch_size, batch_end);
+                for (size_t batch_start = 0; batch_start < positions.size();
+                     batch_start += batch_size) {
+
+                    size_t batch_end = std::min(batch_start + batch_size, positions.size());
+                    size_t current_batch_size = batch_end - batch_start;
+                    size_t subbatch_size = (current_batch_size + thread_count - 1) / thread_count;
+
+                    size_t subbatch_start = batch_start + subbatch_size * thread_idx;
+                    size_t subbatch_end   = std::min(subbatch_start + subbatch_size, batch_end);
                     size_t current_subbatch_size = subbatch_end - subbatch_start;
 
-                    std::vector<ValuePtr> subbatch_outputs;
-                    std::vector<f64>      subbatch_targets;
+                    subbatch_outputs.clear();
+                    subbatch_targets.clear();
                     subbatch_outputs.reserve(current_subbatch_size);
                     subbatch_targets.reserve(current_subbatch_size);
 
-                    Graph::get().cleanup();
                     Graph::get().copy_parameter_values(current_parameter_values);
 
                     for (size_t j = subbatch_start; j < subbatch_end; ++j) {
@@ -164,8 +168,13 @@ int main() {
                     (void)barrier.arrive();
 
                     Graph::get().cleanup();
-                }).detach();
-            }
+                }
+            }).detach();
+        }
+
+        for (size_t batch_idx = 0, batch_start = 0; batch_start < positions.size();
+             batch_start += batch_size, ++batch_idx) {
+            batch_gradients = Parameters::zeros(parameter_count);
 
             barrier.arrive_and_wait();
 

--- a/src/tuning/graph.hpp
+++ b/src/tuning/graph.hpp
@@ -36,18 +36,16 @@ private:
 
     void register_param(const ValuePtr& param) {
         m_parameters.push_back(param);
-        m_backwardables.push_back(std::static_pointer_cast<Backwardable>(param));
     }
 
     void register_param(const PairPtr& param) {
         m_pair_parameters.push_back(param);
-        m_backwardables.push_back(std::static_pointer_cast<Backwardable>(param));
     }
 
 public:
     static Graph& get() {
-        thread_local std::shared_ptr<Graph> instance(new Graph());
-        return *instance;
+        thread_local Graph instance;
+        return instance;
     }
 
     // ------------------ Registration ------------------


### PR DESCRIPTION
Improve performance of mulithreaded tuning.
We also retain the same threads through tuning rather than spawning them per-subbatch, which significantly improves performance on WSL.

Bench: 7561507