### PR TITLE
Increase history bonus and malus when best move fails high by a high margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -583,7 +583,8 @@ Value Worker::search(
     }
 
     if (best_value >= beta) {
-        const i32 bonus = std::min(1896, 4 * depth * depth + 120 * depth - 120);
+        i32       bonus_depth = depth + (best_value >= beta + 75);
+        const i32 bonus = std::min(1896, 4 * bonus_depth * bonus_depth + 120 * bonus_depth - 120);
         if (quiet_move(best_move)) {
             ss->killer = best_move;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -583,7 +583,7 @@ Value Worker::search(
     }
 
     if (best_value >= beta) {
-        i32       bonus_depth = depth + (best_value >= beta + 75);
+        i32       bonus_depth = depth + (best_value >= beta + 100);
         const i32 bonus = std::min(1896, 4 * bonus_depth * bonus_depth + 120 * bonus_depth - 120);
         if (quiet_move(best_move)) {
             ss->killer = best_move;


### PR DESCRIPTION
```
Test  | betabonustake2
Elo   | 5.19 +- 3.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11976 W: 3027 L: 2848 D: 6101
Penta | [151, 1430, 2687, 1529, 191]
```
https://clockworkopenbench.pythonanywhere.com/test/530/

comparison test vs another variant that passed
```
Test  | betabonustake2
Elo   | 1.38 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-2.00, 2.00]
Games | N: 39850 W: 9933 L: 9775 D: 20142
Penta | [614, 4794, 8931, 4992, 594]
```
https://clockworkopenbench.pythonanywhere.com/test/534/

Bench: 7600293