### PR TITLE
Double the weight of all conthists in quiet history score calculations

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -27,7 +27,7 @@ i32 History::get_quiet_stats(const Position& pos, Move move, i32 ply, Search::St
     auto from_attacked = pos.is_square_attacked_by(move.from(), ~pos.active_color());
     i32  stats         = m_main_hist[static_cast<usize>(pos.active_color())][move.from_to()]
                            [from_attacked * 2 + to_attacked];
-    stats += get_conthist(pos, move, ply, ss);
+    stats += 2 * get_conthist(pos, move, ply, ss);
     return stats;
 }
 


### PR DESCRIPTION
```
Test  | double-conthist-weight
Elo   | 17.88 +- 7.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2490 W: 696 L: 568 D: 1226
Penta | [24, 234, 614, 336, 37]
```
https://clockworkopenbench.pythonanywhere.com/test/557/

Bench: 7675928