### PR TITLE
Add ttpv node tracking and ttpv lmr

### DIFF
--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -5,10 +5,10 @@
 namespace Clockwork {
 
 enum Bound : u8 {
-    None,
-    Lower,
-    Upper,
-    Exact,
+    None = 0,
+    Lower = 1,
+    Upper = 2,
+    Exact = 3,
 };
 
 struct TTEntry {
@@ -17,7 +17,7 @@ struct TTEntry {
     i16   score;
     i16   eval;
     u8    depth;
-    Bound bound;
+    u8    ttpv_bound;
 };
 
 static_assert(sizeof(TTEntry) == 10 * sizeof(u8));
@@ -27,7 +27,14 @@ struct TTData {
     Move  move;
     Value score;
     Depth depth;
-    Bound bound;
+    u8    ttpv_bound;
+
+    [[nodiscard]] Bound bound() const {
+        return static_cast<Bound>(ttpv_bound & 0b011);
+    }
+    [[nodiscard]] bool ttpv() const {
+        return static_cast<bool>(ttpv_bound & 0b100);
+    }
 };
 
 class TT {
@@ -45,6 +52,7 @@ public:
                                 Move            move,
                                 Value           score,
                                 Depth           depth,
+                                bool            ttpv,
                                 Bound           bound);
     void                  resize(size_t mb);
     void                  clear();


### PR DESCRIPTION
Should enable a plethora of tweaks

```
Test  | ttpv2
Elo   | 5.67 +- 4.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10046 W: 2542 L: 2378 D: 5126
Penta | [109, 1199, 2284, 1281, 150]
```
https://clockworkopenbench.pythonanywhere.com/test/551/

Bench: 10132115