### PR TITLE
Introduce 6-ply conthist

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -18,6 +18,9 @@ i32 History::get_conthist(const Position& pos, Move move, i32 ply, Search::Stack
     if (ply >= 4 && (ss - 4)->cont_hist_entry != nullptr) {
         stats += (*(ss - 4)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
     }
+    if (ply >= 6 && (ss - 6)->cont_hist_entry != nullptr) {
+        stats += (*(ss - 6)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw];
+    }
 
     return stats;
 }
@@ -51,6 +54,10 @@ void History::update_quiet_stats(
     }
     if (ply >= 4 && (ss - 4)->cont_hist_entry != nullptr) {
         update_hist_entry_banger((*(ss - 4)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw],
+                                 conthist, bonus);
+    }
+    if (ply >= 6 && (ss - 6)->cont_hist_entry != nullptr) {
+        update_hist_entry_banger((*(ss - 6)->cont_hist_entry)[stm_idx][pt_idx][move.to().raw],
                                  conthist, bonus);
     }
 }


### PR DESCRIPTION
```
Test  | ch6-rebased
Elo   | 8.86 +- 5.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5882 W: 1542 L: 1392 D: 2948
Penta | [81, 663, 1318, 783, 96]
```
https://clockworkopenbench.pythonanywhere.com/test/560/

Bench: 9277098