### PR TITLE
mh32-FPP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -379,18 +379,6 @@ Value Worker::search(
                 || (tt_data->bound() == Bound::Upper && tt_data->score <= alpha))) {
             return tt_data->score;
         }
-        
-        // TT-Based ProbCut
-        constexpr Value kProbCutMargin = 480;
-        constexpr Depth kProbCutDepthReduction = 4;
-
-        if (tt_data->bound() == Bound::Lower
-            && tt_data->depth >= depth - kProbCutDepthReduction
-            && tt_data->score >= beta + kProbCutMargin
-            && abs(beta) < VALUE_WIN
-            && abs(tt_data->score) < VALUE_WIN) {
-            return tt_data->score;
-        }
 
         // Update ttpv
         ttpv |= tt_data->ttpv();
@@ -481,8 +469,8 @@ Value Worker::search(
                 break;
             }
 
-            // Forward Futility Pruning
-            Value futility = ss->static_eval + 500 + 100 * depth;
+            // Forward Futility Pruning (FFP)
+            Value futility = ss->static_eval + 500 + 100 * depth + move_history / 32;
             if (quiet && !is_in_check && depth <= 8 && futility <= alpha) {
                 moves.skip_quiets();
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -442,6 +442,58 @@ Value Worker::search(
         }
     }
 
+    // Probcut (Probabilistic Beta Cutoff)
+    if (!PV_NODE && !is_in_check && depth >= 5 && abs(beta) < VALUE_WIN) {
+        // Only try the TT move if it exists and is tactical.
+        if (tt_data && tt_data->move != Move::none() && !quiet_move(tt_data->move)) {
+            
+            do {
+                const Move probcut_move = tt_data->move;
+                
+                MovePicker legality_checker{pos, m_td.history, Move::none(), ply, ss};
+                if (!legality_checker.is_legal(probcut_move)) [[unlikely]] {
+                    break;
+                }
+                
+                constexpr Value kProbCutSEEThreshold = 0;
+                if (!SEE::see(pos, probcut_move, kProbCutSEEThreshold)) [[unlikely]] {
+                    break;
+                }
+
+                // Base margin: 200 internal units (~50cp)
+                constexpr Value kProbCutMargin = 200;
+                // Bonus for improving eval: 50 internal units (~12.5cp)
+                constexpr Value kImprovingBonus = 50;
+                constexpr Depth kProbCutReduction = 4;
+                
+                const Value probcut_beta = beta + kProbCutMargin - (improving ? kImprovingBonus : 0);
+                const Depth probcut_depth = depth - kProbCutReduction;
+
+                static_assert(5 - kProbCutReduction >= 1, "Probcut min depth must be >= 1");
+
+                ss->cont_hist_entry = &m_td.history.get_cont_hist_entry(pos, probcut_move);
+                Position pos_after  = pos.move(probcut_move, m_td.push_psqt_state());
+                repetition_info.push(pos_after.get_hash_key(), pos_after.is_reversible(probcut_move));
+
+                const Value probcut_value = -search<IS_MAIN, false>(
+                    pos_after, ss + 1, -probcut_beta, -probcut_beta + 1, probcut_depth, ply + 1, !cutnode
+                );
+
+                repetition_info.pop();
+                m_td.pop_psqt_state();
+                ss->cont_hist_entry = nullptr;
+
+                if (m_stopped) [[unlikely]] {
+                    return 0;
+                }
+
+                if (probcut_value >= probcut_beta) [[likely]] {
+                    return (probcut_value >= VALUE_WIN) ? probcut_value : beta;
+                }
+            } while (false);
+        }
+    }
+
     MovePicker moves{pos, m_td.history, tt_data ? tt_data->move : Move::none(), ply, ss};
     Move       best_move    = Move::none();
     Value      best_value   = -VALUE_INF;


### PR DESCRIPTION
```
Test  | test/mh32-FFP
Elo   | 8.26 +- 5.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6352 W: 1681 L: 1530 D: 3141
Penta | [77, 723, 1456, 812, 108]
```
https://clockworkopenbench.pythonanywhere.com/test/569/