### PR TITLE
Increase rfp depth and preserve tt move in quiescence if none was found

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -760,7 +760,8 @@ Value Worker::quiesce(const Position& pos, Stack* ss, Value alpha, Value beta, i
 
     // Store to the TT
     Bound bound = best_value >= beta ? Bound::Lower : Bound::Upper;
-    m_searcher.tt.store(pos, ply, raw_eval, best_move, best_value, 0, ttpv, bound);
+    Move  tt_move = best_move != Move::none() ? best_move : tt_data ? tt_data->move : Move::none();
+    m_searcher.tt.store(pos, ply, raw_eval, tt_move, best_value, 0, ttpv, bound);
 
     return best_value;
 }

--- a/src/tuned.hpp
+++ b/src/tuned.hpp
@@ -11,7 +11,7 @@ namespace Clockwork::tuned {
                                                                   \
     /* RFP Values */                                              \
     TUNE(rfp_margin, 147, 40, 160, 4, 0.002)                      \
-    NO_TUNE(rfp_depth, 6, 4, 10, .5, 0.002)                       \
+    NO_TUNE(rfp_depth, 7, 4, 10, .5, 0.002)                       \
                                                                   \
     /* NMP Values */                                              \
     NO_TUNE(nmp_depth, 3, 1, 10, .5, 0.002)                       \


### PR DESCRIPTION
```
Test  | armagaeddonrfpdepthqsttmstore
Elo   | 3.34 +- 2.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23836 W: 6007 L: 5778 D: 12051
Penta | [343, 2885, 5269, 3042, 379]
```
https://clockworkopenbench.pythonanywhere.com/test/564/

Bench: 9706472