### PR TITLE
Add NMP eval diff margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -418,7 +418,7 @@ Value Worker::search(
     }
 
     if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
-        && tt_adjusted_eval >= beta) {
+        && tt_adjusted_eval >= beta + 30) {
         int R =
           tuned::nmp_base_r + depth / 4 + std::min(3, (tt_adjusted_eval - beta) / 400) + improving;
         Position pos_after = pos.null_move();


### PR DESCRIPTION
`tt_adjusted_eval >= beta + 30`

```
Test  | nmp-diff-margin-30
Elo   | 8.14 +- 5.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6614 W: 1720 L: 1565 D: 3329
Penta | [90, 727, 1535, 848, 107]
```
https://clockworkopenbench.pythonanywhere.com/test/577/

Bench: 9153092