### PR TITLE
Tweak noisy tt move lmr to only reduce quiets

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -522,7 +522,7 @@ Value Worker::search(
             }            
 
             if (tt_data && tt_data->move.is_capture()) {
-                reduction += 1024;
+                reduction += 512 + 512 * (!m.is_capture());
             }
 
             if ((ss + 1)->fail_high_count > 3) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -521,8 +521,8 @@ Value Worker::search(
                 reduction += 1024;
             }            
 
-            if (tt_data && tt_data->move.is_capture()) {
-                reduction += 512 + 512 * (!m.is_capture());
+            if (tt_data && tt_data->move.is_capture() && !m.is_capture()) {
+                reduction += 1024;
             }
 
             if ((ss + 1)->fail_high_count > 3) {


### PR DESCRIPTION
Consider adding see failing noisy back (maybe with different reduction)

```
Test  | ttcapturetest2
Elo   | 2.93 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 31076 W: 7891 L: 7629 D: 15556
Penta | [474, 3641, 7028, 3939, 456]
```
https://clockworkopenbench.pythonanywhere.com/test/575/

Bench: 9068248