### PR TITLE
Postpone division in static eval correction calculation (and format)

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -123,14 +123,12 @@ i32 History::get_correction(const Position& pos) {
     usize major_index = static_cast<usize>(major_key % CORRECTION_HISTORY_ENTRY_NB);
 
     i32 correction = 0;
-    correction += m_pawn_corr_hist[side_index][pawn_index] / CORRECTION_HISTORY_GRAIN;
-    correction +=
-      m_non_pawn_corr_hist[0][side_index][white_non_pawn_index] / CORRECTION_HISTORY_GRAIN;
-    correction +=
-      m_non_pawn_corr_hist[1][side_index][black_non_pawn_index] / CORRECTION_HISTORY_GRAIN;
-    correction += m_major_corr_hist[side_index][major_index] / CORRECTION_HISTORY_GRAIN;
+    correction += m_pawn_corr_hist[side_index][pawn_index];
+    correction += m_non_pawn_corr_hist[0][side_index][white_non_pawn_index];
+    correction += m_non_pawn_corr_hist[1][side_index][black_non_pawn_index];
+    correction += m_major_corr_hist[side_index][major_index];
 
-    return correction;
+    return correction / CORRECTION_HISTORY_GRAIN;
 }
 
 void History::clear() {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -371,10 +371,11 @@ Value Worker::search(
     }
 
     auto tt_data = m_searcher.tt.probe(pos, ply);
-    bool ttpv = PV_NODE;
+    bool ttpv    = PV_NODE;
 
     if (!PV_NODE && tt_data) {
-        if (tt_data->depth >= depth && (tt_data->bound() == Bound::Exact
+        if (tt_data->depth >= depth
+            && (tt_data->bound() == Bound::Exact
                 || (tt_data->bound() == Bound::Lower && tt_data->score >= beta)
                 || (tt_data->bound() == Bound::Upper && tt_data->score <= alpha))) {
             return tt_data->score;
@@ -516,10 +517,10 @@ Value Worker::search(
             if (ttpv) {
                 reduction -= 1024;
             }
-            
+
             if (ttpv && tt_data && tt_data->score <= alpha) {
                 reduction += 1024;
-            }            
+            }
 
             if (tt_data && tt_data->move.is_capture() && !m.is_capture()) {
                 reduction += 1024;
@@ -680,11 +681,11 @@ Value Worker::quiesce(const Position& pos, Stack* ss, Value alpha, Value beta, i
         return tt_data->score;
     }
 
-    bool  is_in_check = pos.is_in_check();
-    bool  ttpv =
+    bool is_in_check = pos.is_in_check();
+    bool ttpv =
       tt_data
-         ? tt_data->ttpv()
-         : false;  // TODO: if we ever get to needing ttpv patches in quiescence, we might want to add PV_NODE handling in here also
+        ? tt_data->ttpv()
+        : false;  // TODO: if we ever get to needing ttpv patches in quiescence, we might want to add PV_NODE handling in here also
     Value correction  = 0;
     Value raw_eval    = -VALUE_INF;
     Value static_eval = -VALUE_INF;
@@ -763,7 +764,7 @@ Value Worker::quiesce(const Position& pos, Stack* ss, Value alpha, Value beta, i
     }
 
     // Store to the TT
-    Bound bound = best_value >= beta ? Bound::Lower : Bound::Upper;
+    Bound bound   = best_value >= beta ? Bound::Lower : Bound::Upper;
     Move  tt_move = best_move != Move::none() ? best_move : tt_data ? tt_data->move : Move::none();
     m_searcher.tt.store(pos, ply, raw_eval, tt_move, best_value, 0, ttpv, bound);
 

--- a/src/square.hpp
+++ b/src/square.hpp
@@ -67,7 +67,7 @@ struct Square {
         return Square{static_cast<u8>(raw ^ 56)};
     }
 
-    template <Color color>
+    template<Color color>
     constexpr Square push() const {
         return Square{static_cast<u8>(raw + (color == Color::White ? 8 : -8))};
     }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -78,16 +78,22 @@ std::optional<TTData> TT::probe(const Position& pos, i32 ply) const {
     return {};
 }
 
-void TT::store(
-  const Position& pos, i32 ply, Value eval, Move move, Value score, Depth depth, bool ttpv, Bound bound) {
-    size_t idx   = mulhi64(pos.get_hash_key(), m_size);
-    auto&  entry = m_entries[idx];
-    entry.key16  = shrink_key(pos.get_hash_key());
-    entry.move   = move;
-    entry.score  = score_to_tt(score, ply);
-    entry.eval   = static_cast<i16>(eval);
-    entry.depth  = static_cast<u8>(depth);
-    entry.ttpv_bound  = make_ttpv_bound(ttpv, bound);
+void TT::store(const Position& pos,
+               i32             ply,
+               Value           eval,
+               Move            move,
+               Value           score,
+               Depth           depth,
+               bool            ttpv,
+               Bound           bound) {
+    size_t idx       = mulhi64(pos.get_hash_key(), m_size);
+    auto&  entry     = m_entries[idx];
+    entry.key16      = shrink_key(pos.get_hash_key());
+    entry.move       = move;
+    entry.score      = score_to_tt(score, ply);
+    entry.eval       = static_cast<i16>(eval);
+    entry.depth      = static_cast<u8>(depth);
+    entry.ttpv_bound = make_ttpv_bound(ttpv, bound);
 }
 
 void TT::resize(size_t mb) {

--- a/src/tt.hpp
+++ b/src/tt.hpp
@@ -5,19 +5,19 @@
 namespace Clockwork {
 
 enum Bound : u8 {
-    None = 0,
+    None  = 0,
     Lower = 1,
     Upper = 2,
     Exact = 3,
 };
 
 struct TTEntry {
-    u16   key16;
-    Move  move;
-    i16   score;
-    i16   eval;
-    u8    depth;
-    u8    ttpv_bound;
+    u16  key16;
+    Move move;
+    i16  score;
+    i16  eval;
+    u8   depth;
+    u8   ttpv_bound;
 };
 
 static_assert(sizeof(TTEntry) == 10 * sizeof(u8));


### PR DESCRIPTION
```
Test  | corrhistprecision
Elo   | -0.46 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 59876 W: 15016 L: 15096 D: 29764
Penta | [985, 7274, 13482, 7230, 967]
```
https://clockworkopenbench.pythonanywhere.com/test/620/

Bench: 7808514