### PR TITLE
Adjust reverse futility pruning for zugzwang risk

### DIFF
--- a/src/position.hpp
+++ b/src/position.hpp
@@ -223,6 +223,12 @@ public:
         return true;
     }
 
+    [[nodiscard]] inline bool is_zugzwang_risk() const {
+        const bool stm_has_only_pawns = piece_count(m_active_color) == 1 + piece_count(m_active_color, PieceType::Pawn);
+        const bool opp_has_pieces = piece_count(invert(m_active_color)) > 1 + piece_count(invert(m_active_color), PieceType::Pawn);
+        return stm_has_only_pawns && opp_has_pieces;
+    }
+
     [[nodiscard]] bool is_insufficient_material() const {
         auto wpcnt = piece_count(Color::White);
         auto bpcnt = piece_count(Color::Black);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -412,8 +412,11 @@ Value Worker::search(
         tt_adjusted_eval = tt_data->score;
     }
 
-    if (!PV_NODE && !is_in_check && !pos.is_zugzwang_risk() && depth <= tuned::rfp_depth
-        && tt_adjusted_eval >= beta + tuned::rfp_margin * depth) {
+    Value margin = tuned::rfp_margin * depth;
+    margin += pos.is_zugzwang_risk() * tuned::rfp_zugzwang_bonus;
+
+    if (!PV_NODE && !is_in_check && depth <= tuned::rfp_depth
+        && tt_adjusted_eval >= beta + margin) {
         return tt_adjusted_eval;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -412,7 +412,7 @@ Value Worker::search(
         tt_adjusted_eval = tt_data->score;
     }
 
-    if (!PV_NODE && !is_in_check && depth <= tuned::rfp_depth
+    if (!PV_NODE && !is_in_check && !pos.is_zugzwang_risk() && depth <= tuned::rfp_depth
         && tt_adjusted_eval >= beta + tuned::rfp_margin * depth) {
         return tt_adjusted_eval;
     }

--- a/src/tuned.hpp
+++ b/src/tuned.hpp
@@ -11,6 +11,8 @@ namespace Clockwork::tuned {
                                                                   \
     /* RFP Values */                                              \
     TUNE(rfp_margin, 147, 40, 160, 4, 0.002)                      \
+    TUNE(rfp_zugzwang_bonus, 200, 0, 600, 20, 0.002)              \
+                                                                  \
     NO_TUNE(rfp_depth, 7, 4, 10, .5, 0.002)                       \
                                                                   \
     /* NMP Values */                                              \


### PR DESCRIPTION
In reverse futility pruning (RFP), we return early when our static eval
is already well above beta, assuming the position is so good that even
the opponent's best response cannot bring us below beta.

However, this assumption is less reliable in zugzwang-prone positions
where the side to move has only king and pawns while the opponent has
more pieces. In such cases, the obligation to move can be a disadvantage,
and the static evaluation may be overly optimistic.

This patch identifies zugzwang risk positions and increases the RFP margin
by a tuned bonus, making the pruning more conservative when needed.

```
Test  | tweak/rfp-zugzwang
Elo   | 4.18 +- 3.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14636 W: 3683 L: 3507 D: 7446
Penta | [149, 1621, 3643, 1715, 190]
```
https://clockworkopenbench.pythonanywhere.com/test/631/

Bench: 8450911