### PR TITLE
Add Negative Extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -508,7 +508,8 @@ Value Worker::search(
 
             if (singular_value < singular_beta) {
                 extension++;
-            } 
+            }
+            
             else if (tt_data->score >= beta) {
                 extension--;
             }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,10 @@ Value Worker::search(
             ss->excluded_move    = Move::none();
 
             if (singular_value < singular_beta) {
-                extension = 1;
+                extension++;
+            } 
+            else if (tt_data->score >= beta) {
+                extension--;
             }
         }        
         

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -61,6 +61,7 @@ private:
 struct Stack {
     Value          static_eval     = 0;
     Move           killer          = Move::none();
+    Move           excluded_move;
     ContHistEntry* cont_hist_entry = nullptr;
     i32            fail_high_count = 0;
     PV             pv;


### PR DESCRIPTION
```
Test  | negative-extensions
Elo   | 5.83 +- 4.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9538 W: 2241 L: 2081 D: 5216
Penta | [94, 1102, 2230, 1236, 107]
```
https://clockworkopenbench.pythonanywhere.com/test/643/

bench: 16110967