### PR TITLE
Introduce Complexity Based Soft TM Scaling

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -293,7 +293,7 @@ Move Worker::iterative_deepening(const Position& root_position) {
         if (IS_MAIN && search_depth >= 6) {
             f64 complexity = 0;
             if (abs(score) < VALUE_WIN) {
-                complexity = 0.2 * abs(base_search_score - score) * std::log(search_depth);
+                complexity = 0.6 * abs(base_search_score - score) * std::log(search_depth);
             }
             m_search_limits.soft_time_limit = TM::compute_soft_limit<true>(
               m_search_start, m_searcher.settings, root_position.active_color(), nodes_tm_fraction, complexity);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -178,7 +178,7 @@ void Worker::start_searching() {
           .hard_time_limit = TM::compute_hard_limit(m_search_start, m_searcher.settings,
                                                     root_position.active_color()),
           .soft_time_limit = TM::compute_soft_limit<false>(m_search_start, m_searcher.settings,
-                                                           root_position.active_color(), 0.0),
+                                                           root_position.active_color(), 0.0, 0.0),
           .soft_node_limit = m_searcher.settings.soft_nodes > 0 ? m_searcher.settings.soft_nodes
                                                                 : std::numeric_limits<u64>::max(),
           .hard_node_limit = m_searcher.settings.hard_nodes > 0 ? m_searcher.settings.hard_nodes
@@ -203,6 +203,7 @@ Move Worker::iterative_deepening(const Position& root_position) {
 
     Depth last_search_depth = 0;
     Value last_search_score = -VALUE_INF;
+    Value base_search_score = -VALUE_INF;
     Move  last_best_move    = Move::none();
     PV    last_pv{};
 
@@ -268,6 +269,7 @@ Move Worker::iterative_deepening(const Position& root_position) {
         last_search_score = score;
         last_pv           = ss[SS_PADDING].pv;
         last_best_move    = last_pv.first_move();
+        base_search_score = search_depth == 1 ? score : base_search_score;
 
         // Check depth limit
         if (IS_MAIN && search_depth >= m_search_limits.depth_limit) {
@@ -289,8 +291,12 @@ Move Worker::iterative_deepening(const Position& root_position) {
         // Starting from depth 6, recalculate the soft time limit based on the fraction of nodes (nodes_tm_fraction)
         // We don't do it for too shallow depths because the node distribution is not stable enough
         if (IS_MAIN && search_depth >= 6) {
+            f64 complexity = 0;
+            if (abs(score) < VALUE_WIN) {
+                complexity = 0.2 * abs(base_search_score - score) * std::log(search_depth);
+            }
             m_search_limits.soft_time_limit = TM::compute_soft_limit<true>(
-              m_search_start, m_searcher.settings, root_position.active_color(), nodes_tm_fraction);
+              m_search_start, m_searcher.settings, root_position.active_color(), nodes_tm_fraction, complexity);
         }
 
         // check soft time limit

--- a/src/tm.cpp
+++ b/src/tm.cpp
@@ -34,7 +34,8 @@ template<bool ADJUST_FOR_NODES_TM>
 time::TimePoint compute_soft_limit(time::TimePoint               search_start,
                                    const Search::SearchSettings& settings,
                                    const Color                   stm,
-                                   const f64                     nodes_tm_fraction) {
+                                   const f64                     nodes_tm_fraction,
+                                   const f64                     complexity) {
     using namespace std;
     using namespace time;
 
@@ -59,10 +60,16 @@ time::TimePoint compute_soft_limit(time::TimePoint               search_start,
             return std::max<f64>(0.5, 2.0 - nodes_tm_fraction * (100.0 / 54.038));
         };
 
+        // Adjustment based on difference between depth 1 search score and current score
+        // This essentially estimates the complexity of a position
+        const auto compute_complexitytm_factor = [&]() -> f64 {
+            return std::max<f64>(0.77 + std::clamp<f64>(complexity, 0.0, 200.0) / 386.0, 1.0);
+        };
+
         soft_limit =
           min(soft_limit,
               search_start
-                + Milliseconds(static_cast<i64>(compute_buffer_time() * compute_nodestm_factor())));
+                + Milliseconds(static_cast<i64>(compute_buffer_time() * compute_nodestm_factor() * compute_complexitytm_factor())));
     }
 
     return soft_limit;
@@ -70,8 +77,8 @@ time::TimePoint compute_soft_limit(time::TimePoint               search_start,
 
 // Explicit instantiations
 template time::TimePoint
-compute_soft_limit<true>(time::TimePoint, const Search::SearchSettings&, const Color, const f64);
+compute_soft_limit<true>(time::TimePoint, const Search::SearchSettings&, const Color, const f64, const f64);
 
 template time::TimePoint
-compute_soft_limit<false>(time::TimePoint, const Search::SearchSettings&, const Color, const f64);
+compute_soft_limit<false>(time::TimePoint, const Search::SearchSettings&, const Color, const f64, const f64);
 }

--- a/src/tm.hpp
+++ b/src/tm.hpp
@@ -12,6 +12,7 @@ template<bool ADJUST_FOR_NODES_TM = true>
 time::TimePoint compute_soft_limit(time::TimePoint               search_start,
                                    const Search::SearchSettings& settings,
                                    const Color                   stm,
-                                   const f64                     nodes_tm_fraction);
+                                   const f64                     nodes_tm_fraction,
+                                   const f64                     complexity);
 // Will add soft tm and other helper functions here
 }


### PR DESCRIPTION
STC
```
Test  | complexity-tm
Elo   | 4.92 +- 3.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11292 W: 2653 L: 2493 D: 6146
Penta | [100, 1252, 2799, 1378, 117]
```
https://clockworkopenbench.pythonanywhere.com/test/653/

LTC
```
Test  | complexity-tm
Elo   | 4.47 +- 3.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11726 W: 2625 L: 2474 D: 6627
Penta | [53, 1291, 3036, 1418, 65]
```
https://clockworkopenbench.pythonanywhere.com/test/658/

This patch scales the soft time limit by how much the current search score deviates from the depth 1 score. The idea is that this gives us an estimate of how "complex" a position is and so we should allocate more time depending on it. Note that this will never scale the limit down. Original idea from [Tarnished](https://github.com/Bobingstern/Tarnished/pull/82)