### PR TITLE
Use tt adjusted eval for razoring when available

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -532,7 +532,7 @@ Value Worker::search(
 
     // Razoring
     if (!PV_NODE && !excluded && !is_in_check && depth <= tuned::razor_depth
-        && ss->static_eval + tuned::razor_margin * depth < alpha) {
+        && tt_adjusted_eval + tuned::razor_margin * depth < alpha) {
         const Value razor_score = quiesce<IS_MAIN, PV_NODE>(pos, ss, alpha, beta, ply);
         if (razor_score <= alpha) {
             return razor_score;


### PR DESCRIPTION
Passed nonregr STC:
```
Test  | ttadjustrazor
Elo   | 0.01 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 78362 W: 20327 L: 20324 D: 37711
Penta | [976, 9616, 18061, 9485, 1043]
```
https://ob.cwchess.org/test/1282/

Passed nonregr LTC:
```
Test  | ttadjustrazor
Elo   | 1.97 +- 2.40 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 22908 W: 5533 L: 5403 D: 11972
Penta | [116, 2716, 5667, 2832, 123]
```
https://ob.cwchess.org/test/1290/

Bench; 16687021