### PR TITLE
Only apply null move pruning in expected cut nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -492,7 +492,7 @@ Value Worker::search(
         return tt_adjusted_eval;
     }
 
-    if (!PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth && !excluded
+    if (cutnode && !PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth && !excluded
         && tt_adjusted_eval >= beta + tuned::nmp_beta_margin && !is_being_mated_score(beta)
         && !m_in_nmp_verification) {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -492,9 +492,9 @@ Value Worker::search(
         return tt_adjusted_eval;
     }
 
-    if (cutnode && !PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth && !excluded
-        && tt_adjusted_eval >= beta + tuned::nmp_beta_margin && !is_being_mated_score(beta)
-        && !m_in_nmp_verification) {
+    if (cutnode && !PV_NODE && !is_in_check && !pos.is_kp_endgame() && depth >= tuned::nmp_depth
+        && !excluded && tt_adjusted_eval >= beta + tuned::nmp_beta_margin
+        && !is_being_mated_score(beta) && !m_in_nmp_verification) {
 
         i32 R = tuned::nmp_base_r + depth * tuned::nmp_depth_r
               + std::min(3 * 64, (tt_adjusted_eval - beta) * 64 / tuned::nmp_beta_diff)


### PR DESCRIPTION
Passed STC:
```
Test  | cutnodenmp
Elo   | 1.81 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 73418 W: 18812 L: 18429 D: 36177
Penta | [807, 8838, 17067, 9159, 838]
```
https://ob.cwchess.org/test/1347/

Passed LTC:
```
Test  | cutnodenmp
Elo   | 2.90 +- 2.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 29384 W: 7239 L: 6994 D: 15151
Penta | [114, 3416, 7401, 3633, 128]
```
https://ob.cwchess.org/test/1348/

Bench: 18290913