### PR TITLE
Add better SE guards

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -21,6 +21,10 @@ constexpr bool is_being_mated_score(Value value) {
     return value <= -VALUE_WIN;
 }
 
+constexpr bool is_valid_score(Value value) {
+    return value != -VALUE_INF;
+}
+
 enum class Color {
     White,
     Black

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -467,7 +467,8 @@ Value Worker::search(
         correction      = excluded ? 0 : m_td.history.get_correction(pos);
         raw_eval        = tt_data && !is_mate_score(tt_data->eval) ? tt_data->eval : evaluate(pos);
         ss->static_eval = adj_shuffle(pos, raw_eval) + correction;
-        improving = (ss - 2)->static_eval != -VALUE_INF && ss->static_eval > (ss - 2)->static_eval;
+        improving =
+          is_valid_score((ss - 2)->static_eval) && ss->static_eval > (ss - 2)->static_eval;
 
         if (!tt_data) {
             m_searcher.tt.store(pos, ply, raw_eval, Move::none(), -VALUE_INF, 0, ttpv, Bound::None);
@@ -640,8 +641,9 @@ Value Worker::search(
 
         // Singular extensions
         int extension = 0;
-        if (!excluded && tt_data && m == tt_data->move && depth >= tuned::sing_min_depth
-            && tt_data->depth >= depth - tuned::sing_depth_margin
+        if (!ROOT_NODE && m == tt_data->move && !excluded && tt_data
+            && depth >= tuned::sing_min_depth && is_valid_score(tt_data->score)
+            && !is_mate_score(tt_data->score) && tt_data->depth >= depth - tuned::sing_depth_margin
             && tt_data->bound() != Bound::Upper) {
             Value singular_beta  = tt_data->score - depth * tuned::sing_beta_margin / 64;
             int   singular_depth = depth / 2;


### PR DESCRIPTION
Passed STC nonregr:
```
Test  | semateguard
Elo   | 2.42 +- 2.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 20996 W: 5464 L: 5318 D: 10214
Penta | [251, 2484, 4888, 2618, 257]
```
https://ob.cwchess.org/test/1382/

Passed LTC nonregr:
```
Test  | semateguard
Elo   | 3.17 +- 2.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.07 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 16466 W: 4064 L: 3914 D: 8488
Penta | [68, 1923, 4126, 2023, 93]
```
https://ob.cwchess.org/test/1384/

Bench: 15544260