### PR TITLE
Fix order of checks for tt_data optional in singular extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -641,7 +641,7 @@ Value Worker::search(
 
         // Singular extensions
         int extension = 0;
-        if (!ROOT_NODE && m == tt_data->move && !excluded && tt_data
+        if (!ROOT_NODE && tt_data && m == tt_data->move && !excluded
             && depth >= tuned::sing_min_depth && is_valid_score(tt_data->score)
             && !is_mate_score(tt_data->score) && tt_data->depth >= depth - tuned::sing_depth_margin
             && tt_data->bound() != Bound::Upper) {


### PR DESCRIPTION
Nonfunctional due to second check, but still logically sound-er than what we had before.
Bench: 14793132