### PR TITLE
Pack all the zobrist keys into a 512b vector and use vectorized updates

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -23,22 +23,9 @@ void Position::incrementally_remove_piece(bool         color,
     toggle_rays(from);
 
     // TODO: check if some speed left on the table for zobrist here
-    Color     pcolor    = m_board[from].color();
-    PieceType ptype     = m_board[from].ptype();
-    u64       piece_key = Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)]
-                                                 [static_cast<usize>(ptype)][from.raw];
-    m_hash_key ^= piece_key;
-    if (ptype == PieceType::Pawn) {
-        m_pawn_key ^= piece_key;
-    } else {
-        m_non_pawn_key[static_cast<usize>(pcolor)] ^= piece_key;
-        if (ptype == PieceType::Rook || ptype == PieceType::Queen || ptype == PieceType::King) {
-            m_major_key ^= piece_key;
-        }
-        if (ptype == PieceType::Knight || ptype == PieceType::Bishop || ptype == PieceType::King) {
-            m_minor_key ^= piece_key;
-        }
-    }
+    Color     pcolor = m_board[from].color();
+    PieceType ptype  = m_board[from].ptype();
+    m_zobrist_info.toggle(pcolor, ptype, from);
     updates.removes.push_back({pcolor, ptype, from});
     m_board[from] = Place::empty();
 }
@@ -48,20 +35,7 @@ void Position::incrementally_add_piece(bool color, Place p, Square to, PsqtUpdat
     m_board[to]      = p;
     Color     pcolor = p.color();
     PieceType ptype  = p.ptype();
-    u64       piece_key =
-      Zobrist::piece_square_zobrist[static_cast<usize>(pcolor)][static_cast<usize>(ptype)][to.raw];
-    m_hash_key ^= piece_key;
-    if (ptype == PieceType::Pawn) {
-        m_pawn_key ^= piece_key;
-    } else {
-        m_non_pawn_key[static_cast<usize>(pcolor)] ^= piece_key;
-        if (ptype == PieceType::Rook || ptype == PieceType::Queen || ptype == PieceType::King) {
-            m_major_key ^= piece_key;
-        }
-        if (ptype == PieceType::Knight || ptype == PieceType::Bishop || ptype == PieceType::King) {
-            m_minor_key ^= piece_key;
-        }
-    }
+    m_zobrist_info.toggle(pcolor, ptype, to);
     updates.adds.push_back({pcolor, ptype, to});
 
     m8x64 m = toggle_rays(to);
@@ -73,37 +47,11 @@ void Position::incrementally_mutate_piece(
     PieceType ptype = m_board[sq].ptype();
 
     // TODO: check if some speed left on the table for zobrist here
-    u64 rem_piece_key = Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
-                                                     [static_cast<usize>(ptype)][sq.raw];
-    m_hash_key ^= rem_piece_key;
-    if (ptype == PieceType::Pawn) {
-        m_pawn_key ^= rem_piece_key;
-    } else {
-        m_non_pawn_key[static_cast<usize>(m_board[sq].color())] ^= rem_piece_key;
-        if (ptype == PieceType::Rook || ptype == PieceType::Queen || ptype == PieceType::King) {
-            m_major_key ^= rem_piece_key;
-        }
-        if (ptype == PieceType::Knight || ptype == PieceType::Bishop || ptype == PieceType::King) {
-            m_minor_key ^= rem_piece_key;
-        }
-    }
+    m_zobrist_info.toggle(m_board[sq].color(), ptype, sq);
     updates.removes.push_back({m_board[sq].color(), ptype, sq});
-    m_board[sq]       = p;
-    ptype             = m_board[sq].ptype();
-    u64 add_piece_key = Zobrist::piece_square_zobrist[static_cast<usize>(m_board[sq].color())]
-                                                     [static_cast<usize>(ptype)][sq.raw];
-    m_hash_key ^= add_piece_key;
-    if (ptype == PieceType::Pawn) {
-        m_pawn_key ^= add_piece_key;
-    } else {
-        m_non_pawn_key[static_cast<usize>(m_board[sq].color())] ^= add_piece_key;
-        if (ptype == PieceType::Rook || ptype == PieceType::Queen || ptype == PieceType::King) {
-            m_major_key ^= add_piece_key;
-        }
-        if (ptype == PieceType::Knight || ptype == PieceType::Bishop || ptype == PieceType::King) {
-            m_minor_key ^= add_piece_key;
-        }
-    }
+    m_board[sq] = p;
+    ptype       = m_board[sq].ptype();
+    m_zobrist_info.toggle(p.color(), ptype, sq);
     updates.adds.push_back({p.color(), p.ptype(), sq});
 
     remove_attacks(old_color, old_id);
@@ -120,44 +68,14 @@ void Position::incrementally_move_piece(
 
     // TODO: check if some speed left on the table for zobrist here
     PieceType from_ptype = m_board[from].ptype();
-    u64 rem_piece_key    = Zobrist::piece_square_zobrist[static_cast<usize>(m_board[from].color())]
-                                                     [static_cast<usize>(from_ptype)][from.raw];
-    m_hash_key ^= rem_piece_key;
-    if (from_ptype == PieceType::Pawn) {
-        m_pawn_key ^= rem_piece_key;
-    } else {
-        m_non_pawn_key[static_cast<usize>(m_board[from].color())] ^= rem_piece_key;
-        if (from_ptype == PieceType::Rook || from_ptype == PieceType::Queen
-            || from_ptype == PieceType::King) {
-            m_major_key ^= rem_piece_key;
-        }
-        if (from_ptype == PieceType::Knight || from_ptype == PieceType::Bishop
-            || from_ptype == PieceType::King) {
-            m_minor_key ^= rem_piece_key;
-        }
-    }
+    m_zobrist_info.toggle(m_board[from].color(), from_ptype, from);
     updates.removes.push_back({m_board[from].color(), from_ptype, from});
 
     m_board[from] = Place::empty();
     m_board[to]   = p;
 
-    PieceType to_ptype      = p.ptype();
-    u64       add_piece_key = Zobrist::piece_square_zobrist[static_cast<usize>(m_board[to].color())]
-                                                     [static_cast<usize>(to_ptype)][to.raw];
-    m_hash_key ^= add_piece_key;
-    if (to_ptype == PieceType::Pawn) {
-        m_pawn_key ^= add_piece_key;
-    } else {
-        m_non_pawn_key[static_cast<usize>(m_board[to].color())] ^= add_piece_key;
-        if (to_ptype == PieceType::Rook || to_ptype == PieceType::Queen
-            || to_ptype == PieceType::King) {
-            m_major_key ^= add_piece_key;
-        }
-        if (to_ptype == PieceType::Knight || to_ptype == PieceType::Bishop
-            || to_ptype == PieceType::King) {
-            m_minor_key ^= add_piece_key;
-        }
-    }
+    PieceType to_ptype = p.ptype();
+    m_zobrist_info.toggle(p.color(), to_ptype, to);
     updates.adds.push_back({p.color(), p.ptype(), to});
 
     u8x64 dst_ray_places = dst_ray_coords.swizzle(m_board.to_vector());
@@ -378,18 +296,18 @@ Position Position::move(Move m, PsqtState* psqtState, const TT* tt) const {
     bool   color = static_cast<bool>(m_active_color);
 
     // move() makes a legal, non null move, so we always swap sides.
-    new_pos.m_hash_key ^= Zobrist::side_key;
+    HashKey non_psqt_update = Zobrist::side_key;
 
     if (m_enpassant.is_valid()) {
         // Remove hash for ep square
-        new_pos.m_hash_key ^= Zobrist::en_passant_zobrist[new_pos.m_enpassant.raw];
+        non_psqt_update ^= Zobrist::en_passant_zobrist[m_enpassant.raw];
         new_pos.m_enpassant = Square::invalid();
     }
 
     // Compute old castle index for zobrist indexing and remove it
     usize old_castle_index =
       new_pos.m_rook_info[0].as_index() | (new_pos.m_rook_info[1].as_index() << 2);
-    new_pos.m_hash_key ^= Zobrist::castling_zobrist[old_castle_index];
+    non_psqt_update ^= Zobrist::castling_zobrist[old_castle_index];
 
     const auto CHECK_SRC_CASTLING_RIGHTS = [&] {
         if (src.ptype() == PieceType::Rook) {
@@ -418,7 +336,7 @@ Position Position::move(Move m, PsqtState* psqtState, const TT* tt) const {
                 Square ep   = Square{static_cast<u8>((from.raw + to.raw) / 2)};
                 if (is_square_attacked_by(ep, them, PieceType::Pawn)) {
                     new_pos.m_enpassant = ep;
-                    new_pos.m_hash_key ^= Zobrist::en_passant_zobrist[new_pos.m_enpassant.raw];
+                    non_psqt_update ^= Zobrist::en_passant_zobrist[ep.raw];
                 }
             }
         } else {
@@ -513,11 +431,14 @@ Position Position::move(Move m, PsqtState* psqtState, const TT* tt) const {
     // Calculate the new castling index for zobrist indexing and add it back in
     usize new_castle_index =
       new_pos.m_rook_info[0].as_index() | (new_pos.m_rook_info[1].as_index() << 2);
-    new_pos.m_hash_key ^= Zobrist::castling_zobrist[new_castle_index];
+    non_psqt_update ^= Zobrist::castling_zobrist[new_castle_index];
+
+    // Update the full key with the non-PSQT updates we've accumulated
+    new_pos.m_zobrist_info.update_fullkey(non_psqt_update);
 
     // Prefetch hash key tt entry
     if (tt != nullptr) {
-        prefetch(tt->addr_key(new_pos.m_hash_key));
+        prefetch(tt->addr_key(new_pos.m_zobrist_info.full_key()));
     }
 
     new_pos.m_active_color = invert(m_active_color);
@@ -535,11 +456,11 @@ template Position Position::move<false>(Move m, PsqtState* psqtState, const TT* 
 
 Position Position::null_move() const {
     Position new_pos = *this;
-    new_pos.m_hash_key ^= Zobrist::side_key;
+    new_pos.m_zobrist_info.update_fullkey(Zobrist::side_key);
 
     if (m_enpassant.is_valid()) {
         // Remove hash for ep square
-        new_pos.m_hash_key ^= Zobrist::en_passant_zobrist[new_pos.m_enpassant.raw];
+        new_pos.m_zobrist_info.update_fullkey(Zobrist::en_passant_zobrist[new_pos.m_enpassant.raw]);
         new_pos.m_enpassant = Square::invalid();
     }
 
@@ -917,11 +838,10 @@ std::optional<Position> Position::parse(std::string_view board,
     }
 
     result.m_attack_table = result.calc_attacks_slow();
-    result.m_hash_key     = result.calc_hash_key_slow();
-    result.m_pawn_key     = result.calc_pawn_key_slow();
-    result.m_non_pawn_key = result.calc_non_pawn_key_slow();
-    result.m_major_key    = result.calc_major_key_slow();
-    result.m_minor_key    = result.calc_minor_key_slow();
+    // Initialize ZobristInfo
+    result.m_zobrist_info = ZobristInfo(result.calc_hash_key_slow(), result.calc_pawn_key_slow(),
+                                        result.calc_non_pawn_key_slow(),
+                                        result.calc_major_key_slow(), result.calc_minor_key_slow());
 
     return result;
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -450,14 +450,16 @@ template Position Position::move<true>(Move m, PsqtState* psqtState, const TT* t
 template Position Position::move<false>(Move m, PsqtState* psqtState, const TT* tt = nullptr) const;
 
 Position Position::null_move() const {
-    Position new_pos = *this;
-    new_pos.m_zobrist_info.update_fullkey(Zobrist::side_key);
+    Position new_pos         = *this;
+    HashKey  non_psqt_update = Zobrist::side_key;
 
     if (m_enpassant.is_valid()) {
         // Remove hash for ep square
-        new_pos.m_zobrist_info.update_fullkey(Zobrist::en_passant_zobrist[new_pos.m_enpassant.raw]);
+        non_psqt_update ^= Zobrist::en_passant_zobrist[m_enpassant.raw];
         new_pos.m_enpassant = Square::invalid();
     }
+
+    new_pos.m_zobrist_info.update_fullkey(non_psqt_update);
 
     new_pos.m_active_color = invert(m_active_color);
     new_pos.m_ply++;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -21,8 +21,6 @@ void Position::incrementally_remove_piece(bool         color,
                                           PsqtUpdates& updates) {
     remove_attacks(color, id);
     toggle_rays(from);
-
-    // TODO: check if some speed left on the table for zobrist here
     Color     pcolor = m_board[from].color();
     PieceType ptype  = m_board[from].ptype();
     m_zobrist_info.toggle(pcolor, ptype, from);
@@ -31,7 +29,6 @@ void Position::incrementally_remove_piece(bool         color,
 }
 
 void Position::incrementally_add_piece(bool color, Place p, Square to, PsqtUpdates& updates) {
-    // TODO: check if some speed left on the table for zobrist here
     m_board[to]      = p;
     Color     pcolor = p.color();
     PieceType ptype  = p.ptype();
@@ -46,7 +43,6 @@ void Position::incrementally_mutate_piece(
   bool old_color, PieceId old_id, Square sq, bool new_color, Place p, PsqtUpdates& updates) {
     PieceType ptype = m_board[sq].ptype();
 
-    // TODO: check if some speed left on the table for zobrist here
     m_zobrist_info.toggle(m_board[sq].color(), ptype, sq);
     updates.removes.push_back({m_board[sq].color(), ptype, sq});
     m_board[sq] = p;
@@ -66,7 +62,6 @@ void Position::incrementally_move_piece(
     auto [dst_ray_coords, dst_ray_valid] = geometry::superpiece_rays(to);
     u8x64 src_ray_places                 = src_ray_coords.swizzle(m_board.to_vector());
 
-    // TODO: check if some speed left on the table for zobrist here
     PieceType from_ptype = m_board[from].ptype();
     m_zobrist_info.toggle(m_board[from].color(), from_ptype, from);
     updates.removes.push_back({m_board[from].color(), from_ptype, from});

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -5,6 +5,7 @@
 #include "square.hpp"
 #include "tt.hpp"
 #include "util/types.hpp"
+#include "zobrist.hpp"
 #include <array>
 #include <bit>
 #include <cassert>
@@ -17,6 +18,7 @@ class TT;
 
 struct PsqtState;
 struct PsqtUpdates;
+
 
 template<typename T>
 struct alignas(16) PieceList {
@@ -120,20 +122,20 @@ public:
     [[nodiscard]] RookInfo rook_info(Color color) const {
         return m_rook_info[static_cast<usize>(color)];
     }
-    [[nodiscard]] HashKey get_hash_key() const {
-        return m_hash_key;
+    [[nodiscard]] inline HashKey get_hash_key() const {
+        return m_zobrist_info.full_key();
     }
-    [[nodiscard]] HashKey get_pawn_key() const {
-        return m_pawn_key;
+    [[nodiscard]] inline HashKey get_pawn_key() const {
+        return m_zobrist_info.pawn_key();
     }
-    [[nodiscard]] HashKey get_non_pawn_key(Color color) const {
-        return m_non_pawn_key[static_cast<usize>(color)];
+    [[nodiscard]] inline HashKey get_non_pawn_key(Color color) const {
+        return m_zobrist_info.non_pawn_key(color);
     }
-    [[nodiscard]] HashKey get_major_key() const {
-        return m_major_key;
+    [[nodiscard]] inline HashKey get_major_key() const {
+        return m_zobrist_info.major_key();
     }
-    [[nodiscard]] HashKey get_minor_key() const {
-        return m_minor_key;
+    [[nodiscard]] inline HashKey get_minor_key() const {
+        return m_zobrist_info.minor_key();
     }
 
     [[nodiscard]] Square king_sq(Color color) const {
@@ -326,17 +328,13 @@ private:
     std::array<PieceList<Square>, 2>    m_piece_list_sq{};
     std::array<PieceList<PieceType>, 2> m_piece_list{};
     Byteboard                           m_board{};
-    u64                                 m_hash{};
     u16                                 m_50mr{};
     u16                                 m_ply{};
     Color                               m_active_color{};
     Square                              m_enpassant = Square::invalid();
     std::array<RookInfo, 2>             m_rook_info;
-    HashKey                             m_hash_key;
-    HashKey                             m_pawn_key;
-    std::array<HashKey, 2>              m_non_pawn_key;
-    HashKey                             m_major_key;
-    HashKey                             m_minor_key;
+
+    ZobristInfo m_zobrist_info;
 
     void incrementally_remove_piece(bool color, PieceId id, Square sq, PsqtUpdates& updates);
     void incrementally_add_piece(bool color, Place p, Square sq, PsqtUpdates& updates);

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -33,13 +33,8 @@ void Zobrist::init_zobrist_keys() {
     // Stm zobrist
     side_key = Random::rand_64();
 
-    // Initialize piece_zobrist_info using the update rules:
-    // Each piece initializes the full key
-    // Pawns also initialize the pawn key
-    // Non-pawns also initialize the non-pawn key for their color
-    // Major pieces and king also initialize the major piece key
-    // Minor pieces and king also initialize the minor piece key
-    // IMPORTANT! From now on, the update rules of the secondary keys go here, not in the position class.
+    // Initialize piece_zobrist_info using the correct per piecetype/color update rules.
+    // IMPORTANT! From now on, the update rules of the secondary keys go here, new key's update rules should be added here.
     for (size_t color_index = 0; color_index < 2; ++color_index) {
         for (size_t piece_index = 1; piece_index < 7; ++piece_index) {
             for (size_t sq_index = 0; sq_index < 64; ++sq_index) {

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -39,6 +39,7 @@ void Zobrist::init_zobrist_keys() {
     // Non-pawns also initialize the non-pawn key for their color
     // Major pieces and king also initialize the major piece key
     // Minor pieces and king also initialize the minor piece key
+    // IMPORTANT! From now on, the update rules of the secondary keys go here, not in the position class.
     for (size_t color_index = 0; color_index < 2; ++color_index) {
         for (size_t piece_index = 1; piece_index < 7; ++piece_index) {
             for (size_t sq_index = 0; sq_index < 64; ++sq_index) {

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -9,6 +9,8 @@ std::array<HashKey, 64>                               Zobrist::en_passant_zobris
 std::array<HashKey, 16>                               Zobrist::castling_zobrist{};
 HashKey                                               Zobrist::side_key = 0;
 
+std::array<std::array<std::array<ZobristInfo, 64>, 7>, 2> Zobrist::piece_zobrist_info{};
+
 
 void Zobrist::init_zobrist_keys() {
     // PieceType - Square zobrists
@@ -30,6 +32,38 @@ void Zobrist::init_zobrist_keys() {
     }
     // Stm zobrist
     side_key = Random::rand_64();
+
+    // Initialize piece_zobrist_info using the update rules:
+    // Each piece initializes the full key
+    // Pawns also initialize the pawn key
+    // Non-pawns also initialize the non-pawn key for their color
+    // Major pieces and king also initialize the major piece key
+    // Minor pieces and king also initialize the minor piece key
+    for (size_t color_index = 0; color_index < 2; ++color_index) {
+        for (size_t piece_index = 1; piece_index < 7; ++piece_index) {
+            for (size_t sq_index = 0; sq_index < 64; ++sq_index) {
+                HashKey piece_key = piece_square_zobrist[color_index][piece_index][sq_index];
+                HashKey pawn_key =
+                  (piece_index == static_cast<size_t>(PieceType::Pawn)) ? piece_key : 0;
+                HashKey non_pawn_key =
+                  (piece_index != static_cast<size_t>(PieceType::Pawn)) ? piece_key : 0;
+                HashKey major_key = (piece_index == static_cast<size_t>(PieceType::Rook)
+                                     || piece_index == static_cast<size_t>(PieceType::Queen)
+                                     || piece_index == static_cast<size_t>(PieceType::King))
+                                    ? piece_key
+                                    : 0;
+                HashKey minor_key = (piece_index == static_cast<size_t>(PieceType::Knight)
+                                     || piece_index == static_cast<size_t>(PieceType::Bishop)
+                                     || piece_index == static_cast<size_t>(PieceType::King))
+                                    ? piece_key
+                                    : 0;
+
+                ZobristInfo info(piece_key, pawn_key, (color_index == 0) ? non_pawn_key : 0,
+                                 (color_index == 1) ? non_pawn_key : 0, major_key, minor_key);
+                piece_zobrist_info[color_index][piece_index][sq_index] = info;
+            }
+        }
+    }
 }
 
 }  // namespace Clockwork

--- a/src/zobrist.hpp
+++ b/src/zobrist.hpp
@@ -10,17 +10,6 @@ namespace Clockwork {
 
 struct alignas(64) ZobristInfo {
     u64x8 m_raw = {};
-
-    // Structure:
-    // [0] - full zobrist key
-    // [1] - pawn key
-    // [2] - non-pawn key for white
-    // [3] - non-pawn key for black
-    // [4] - major piece key
-    // [5] - minor piece key
-    // [6-7] - padding
-
-    // Constructor from the individual components
     constexpr ZobristInfo(HashKey piece_key,
                           HashKey pawn_key,
                           HashKey non_pawn_key_white,
@@ -34,7 +23,6 @@ struct alignas(64) ZobristInfo {
         }} {
     }
 
-    // Alternative constructor that takes std::array for the nonpawn keys
     constexpr ZobristInfo(HashKey                piece_key,
                           HashKey                pawn_key,
                           std::array<HashKey, 2> non_pawn_keys,
@@ -43,12 +31,10 @@ struct alignas(64) ZobristInfo {
         ZobristInfo(piece_key, pawn_key, non_pawn_keys[0], non_pawn_keys[1], major_key, minor_key) {
     }
 
-    // Default constructor
     constexpr ZobristInfo() :
         m_raw{} {
     }
 
-    // Operator ==
     constexpr bool operator==(const ZobristInfo& other) const {
         return m_raw == other.m_raw;
     }

--- a/src/zobrist.hpp
+++ b/src/zobrist.hpp
@@ -1,9 +1,80 @@
 #pragma once
 
+#include "common.hpp"
+#include "square.hpp"
 #include "util/types.hpp"
 #include <array>
 
 namespace Clockwork {
+
+
+struct alignas(64) ZobristInfo {
+    u64x8 m_raw = {};
+
+    // Structure:
+    // [0] - full zobrist key
+    // [1] - pawn key
+    // [2] - non-pawn key for white
+    // [3] - non-pawn key for black
+    // [4] - major piece key
+    // [5] - minor piece key
+    // [6-7] - padding
+
+    // Constructor from the individual components
+    constexpr ZobristInfo(HashKey piece_key,
+                          HashKey pawn_key,
+                          HashKey non_pawn_key_white,
+                          HashKey non_pawn_key_black,
+                          HashKey major_key,
+                          HashKey minor_key) :
+        m_raw{{
+          piece_key, pawn_key, non_pawn_key_white, non_pawn_key_black, major_key, minor_key,
+          0ull,  // padding
+          0ull   // padding
+        }} {
+    }
+
+    // Alternative constructor that takes std::array for the nonpawn keys
+    constexpr ZobristInfo(HashKey                piece_key,
+                          HashKey                pawn_key,
+                          std::array<HashKey, 2> non_pawn_keys,
+                          HashKey                major_key,
+                          HashKey                minor_key) :
+        ZobristInfo(piece_key, pawn_key, non_pawn_keys[0], non_pawn_keys[1], major_key, minor_key) {
+    }
+
+    // Default constructor
+    constexpr ZobristInfo() :
+        m_raw{} {
+    }
+
+    // Operator ==
+    constexpr bool operator==(const ZobristInfo& other) const {
+        return m_raw == other.m_raw;
+    }
+
+    inline void toggle(const Color color, const PieceType ptype, const Square sq);
+
+    inline void update_fullkey(HashKey update) {
+        m_raw ^= u64x8({update, 0, 0, 0, 0, 0, 0, 0});
+    }
+
+    [[nodiscard]] HashKey full_key() const {
+        return m_raw.read(0);
+    }
+    [[nodiscard]] HashKey pawn_key() const {
+        return m_raw.read(1);
+    }
+    [[nodiscard]] HashKey non_pawn_key(Color color) const {
+        return m_raw.read(2 + static_cast<usize>(color));
+    }
+    [[nodiscard]] HashKey major_key() const {
+        return m_raw.read(4);
+    }
+    [[nodiscard]] HashKey minor_key() const {
+        return m_raw.read(5);
+    }
+};
 
 class Zobrist {
 public:
@@ -14,7 +85,20 @@ public:
     static std::array<HashKey, 16>                               castling_zobrist;
     static HashKey                                               side_key;
 
+    // ZobristInfo update table
+    static std::array<std::array<std::array<ZobristInfo, 64>, 7>, 2> piece_zobrist_info;
+
     static void init_zobrist_keys();
 };
+
+inline void ZobristInfo::toggle(const Color color, const PieceType ptype, const Square sq) {
+    const ZobristInfo& info =
+      Zobrist::piece_zobrist_info[static_cast<usize>(color)][static_cast<usize>(ptype)][sq.raw];
+    m_raw ^= info.m_raw;
+}
+
+
+// Make sure to align to u64x8
+
 
 }  // namespace Clockwork

--- a/src/zobrist.hpp
+++ b/src/zobrist.hpp
@@ -7,7 +7,6 @@
 
 namespace Clockwork {
 
-
 struct alignas(64) ZobristInfo {
     u64x8 m_raw = {};
     constexpr ZobristInfo(HashKey piece_key,
@@ -82,9 +81,5 @@ inline void ZobristInfo::toggle(const Color color, const PieceType ptype, const 
       Zobrist::piece_zobrist_info[static_cast<usize>(color)][static_cast<usize>(ptype)][sq.raw];
     m_raw ^= info.m_raw;
 }
-
-
-// Make sure to align to u64x8
-
 
 }  // namespace Clockwork


### PR DESCRIPTION
```
Test  | zobrist_speedup
Elo   | 4.20 +- 2.78 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21746 W: 6168 L: 5905 D: 9673
Penta | [362, 2351, 5207, 2568, 385]
```
https://ob.cwchess.org/test/1451/

Bench: 15108078