### PR TITLE
Move restricted squares to threats to recycle already calculated strong protection

### DIFF
--- a/src/eval_constants.hpp
+++ b/src/eval_constants.hpp
@@ -18,7 +18,7 @@ inline const PParam BISHOP_PAIR_VAL   = S(64, 230);
 inline const PParam ROOK_OPEN_VAL     = S(109, -2);
 inline const PParam ROOK_SEMIOPEN_VAL = S(43, 13);
 inline const PParam MINOR_BEHIND_PAWN = S(15, 39);
-inline const PParam RESTRICTED_SQUARES = S(-20, -4);
+inline const PParam RESTRICTED_SQUARES = S(20, 4);
 
 inline const PParam DOUBLED_PAWN_VAL = S(-20, -82);
 inline const PParam ISOLATED_PAWN_VAL = S(-14, -36);

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -533,6 +533,9 @@ PScore evaluate_threats(const Position& pos, const EvalData& data) {
         eval += HANGING_NON_PAWN * (b & opp_non_pawn).ipopcount();
     }
 
+    eval += RESTRICTED_SQUARES
+          * (data.attacked_by(color) & ~strongly_protected & data.attacked_by(opp)).ipopcount();
+
     Bitboard pawn_attacks = data.attacked_by(color, PieceType::Pawn);
     eval +=
       PAWN_THREAT_KNIGHT * (pos.bitboard_for(opp, PieceType::Knight) & pawn_attacks).ipopcount();
@@ -594,12 +597,6 @@ PScore evaluate_space(const Position& pos, const EvalData& data) {
           * (ourminors.shift_relative(color, Direction::North)
              & (pos.bitboard_for(them, PieceType::Pawn) | pos.bitboard_for(color, PieceType::Pawn)))
               .ipopcount();
-
-    Bitboard strongly_defended = data.attacked_by(color, PieceType::Pawn)
-                               | (data.attacked_by_2(color) & ~data.attacked_by_2(them));
-
-    eval += RESTRICTED_SQUARES
-          * (data.attacked_by(color) & ~strongly_defended & data.attacked_by(them)).ipopcount();
 
     return eval;
 }


### PR DESCRIPTION
No measurable speedup from a single run of `clockwork speedtest` on my machine. Also required flipping the sign because of different perspective.

Bench: 15632420