### PR TITLE
Tweak rfp margin in improving nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -489,7 +489,7 @@ Value Worker::search(
     }
 
     if (!PV_NODE && !is_in_check && depth <= tuned::rfp_depth && !excluded
-        && tt_adjusted_eval >= beta + tuned::rfp_margin * depth) {
+        && tt_adjusted_eval >= beta + tuned::rfp_margin * (depth - improving)) {
         return tt_adjusted_eval;
     }
 


### PR DESCRIPTION
Passed STC:
```
Test  | improvingrfp2
Elo   | 18.20 +- 6.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4166 W: 1204 L: 986 D: 1976
Penta | [38, 447, 920, 615, 63]
```
https://ob.cwchess.org/test/1508/

Passed LTC:
```
Test  | improvingrfp2
Elo   | 1.74 +- 1.40 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 66766 W: 16662 L: 16328 D: 33776
Penta | [349, 7808, 16733, 8146, 347]
```
https://ob.cwchess.org/test/1509/

Bench: 12898941