### PR TITLE
* Fixed the bug where stack size is not correctly set on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ function(target_add_flags target)
     # Stack size
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_link_options(${target} PUBLIC -Wl,-z,stack-size=8388608) # 8 MB
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "MSYS")
         target_link_options(${target} PUBLIC "-Wl,--stack,8388608") # 8 MB for MinGW/Clang
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ function(target_add_flags target)
     # Stack size
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_link_options(${target} PUBLIC -Wl,-z,stack-size=8388608) # 8 MB
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "MSYS")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "MSYS" OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
         target_link_options(${target} PUBLIC "-Wl,--stack,8388608") # 8 MB for MinGW/Clang
     endif()
 


### PR DESCRIPTION
This fixes the bug where Windows did not use 8 MB stack size. Turns out the correct platform is MSYS not Windows