### PR TITLE
Fix bug affecting reversible status of pawn moves for threefold repetition detection

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -991,7 +991,7 @@ std::ostream& operator<<(std::ostream& os, const Position& position) {
     return os;
 }
 
-bool Position::is_reversible(Move move) {
+bool Position::is_reversible(Move move) const {
     return !(move.is_capture() || move.is_promotion() || move.is_castle()
              || (m_board[move.from()].ptype() == PieceType::Pawn));
 }

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -305,7 +305,7 @@ public:
 
     [[nodiscard]] u16 get_50mr_counter() const;
 
-    [[nodiscard]] bool is_reversible(Move move);
+    [[nodiscard]] bool is_reversible(Move move) const;
 
     const std::array<Wordboard, 2> calc_attacks_slow();
     const std::array<PieceMask, 2> calc_attacks_slow(Square sq);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -634,10 +634,8 @@ Value Worker::search(
 
         if (!ROOT_NODE && !is_being_mated_score(best_value)) {
             // Late Move Pruning (LMP)
-            if (moves_played >= (tuned::lmp_depth_mult + depth * depth) / (2 - improving)
-                                  + move_history / 12288) {
-                moves.skip_quiets();
-                continue;
+            if (moves_played >= (tuned::lmp_depth_mult + depth * depth) / (2 - improving)) {
+                break;
             }
 
             // Forward Futility Pruning (FFP)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,7 +579,7 @@ Value Worker::search(
 
                 ss->cont_hist_entry = &m_td.history.get_cont_hist_entry(pos, m);
                 Position pos_after  = pos.move(m, m_td.push_psqt_state(), &m_searcher.tt);
-                repetition_info.push(pos_after.get_hash_key(), pos_after.is_reversible(m));
+                repetition_info.push(pos_after.get_hash_key(), pos.is_reversible(m));
 
                 Value probcut_value = -quiesce<IS_MAIN, false>(pos_after, ss + 1, -probcut_beta,
                                                                -probcut_beta + 1, ply + 1);
@@ -634,8 +634,10 @@ Value Worker::search(
 
         if (!ROOT_NODE && !is_being_mated_score(best_value)) {
             // Late Move Pruning (LMP)
-            if (moves_played >= (tuned::lmp_depth_mult + depth * depth) / (2 - improving)) {
-                break;
+            if (moves_played >= (tuned::lmp_depth_mult + depth * depth) / (2 - improving)
+                                  + move_history / 12288) {
+                moves.skip_quiets();
+                continue;
             }
 
             // Forward Futility Pruning (FFP)
@@ -740,7 +742,7 @@ Value Worker::search(
         moves_played++;
 
         // Put hash into repetition table. TODO: encapsulate this and any other future adjustment to do "on move" into a proper function
-        repetition_info.push(pos_after.get_hash_key(), pos_after.is_reversible(m));
+        repetition_info.push(pos_after.get_hash_key(), pos.is_reversible(m));
 
         // Get search value
         Depth new_depth = depth - 1 + extension;
@@ -1066,7 +1068,7 @@ Value Worker::quiesce(const Position& pos, Stack* ss, Value alpha, Value beta, i
         moves.skip_quiets();
 
         // Put hash into repetition table. TODO: encapsulate this and any other future adjustment to do "on move" into a proper function
-        repetition_info.push(pos_after.get_hash_key(), pos_after.is_reversible(m));
+        repetition_info.push(pos_after.get_hash_key(), pos.is_reversible(m));
 
         // Get search value
         Value value = -quiesce<IS_MAIN, PV_NODE>(pos_after, ss + 1, -beta, -alpha, ply + 1);


### PR DESCRIPTION
Slight speedup, nonfunctional otherwise. Thanks to @Ciekce for spotting this.

```
Test  | fixreversible
Elo   | 0.34 +- 1.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 56760 W: 14923 L: 14867 D: 26970
Penta | [593, 6120, 14874, 6224, 569]
```
https://ob.cwchess.org/test/1548/

Bench: 13841007