### PR TITLE
add bad noisy futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -781,6 +781,15 @@ Value Worker::search(
             if (!SEE::see(pos, m, see_threshold - move_history * tuned::see_pvs_hist_mult / 1024)) {
                 continue;
             }
+
+            int bad_noisy_futility_margin = static_eval + 75 * depth;
+            if (!is_in_check && depth <= 8 &&  && moves.stage() == MovePicker::Stage::EmitBadNoisy && bad_noisy_futility_margin <= alpha) {
+                if (!is_decisive_score(beta) && best_value < bad_noisy_futility_margin) {
+                    best_value = bad_noisy_futility_margin;
+                }
+                
+                break;
+            }
         }
 
         // Singular extensions

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,12 +784,11 @@ Value Worker::search(
 
             Value bad_noisy_futility_margin = ss->static_eval + 75 * depth;
             // Bad Noisy Futility Pruning
-            if (!is_in_check && depth <= 8
-                && moves.stage() == MovePicker::Stage::EmitBadNoisy
+            if (!is_in_check && depth <= 8 && moves.stage() == MovePicker::Stage::EmitBadNoisy
                 && bad_noisy_futility_margin <= alpha) {
                 if (!is_decisive_score(beta) && best_value < bad_noisy_futility_margin) {
                     best_value = bad_noisy_futility_margin;
-                }                
+                }
                 break;
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -782,8 +782,10 @@ Value Worker::search(
                 continue;
             }
 
-            int bad_noisy_futility_margin = static_eval + 75 * depth;
-            if (!is_in_check && depth <= 8 &&  && moves.stage() == MovePicker::Stage::EmitBadNoisy && bad_noisy_futility_margin <= alpha) {
+            Value bad_noisy_futility_margin = ss->static_eval + 75 * depth;
+            if (!is_in_check && depth <= 8
+                && moves.stage() == MovePicker::Stage::EmitBadNoisy
+                && bad_noisy_futility_margin <= alpha) {
                 if (!is_decisive_score(beta) && best_value < bad_noisy_futility_margin) {
                     best_value = bad_noisy_futility_margin;
                 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -783,13 +783,13 @@ Value Worker::search(
             }
 
             Value bad_noisy_futility_margin = ss->static_eval + 75 * depth;
+            // Bad Noisy Futility Pruning
             if (!is_in_check && depth <= 8
                 && moves.stage() == MovePicker::Stage::EmitBadNoisy
                 && bad_noisy_futility_margin <= alpha) {
                 if (!is_decisive_score(beta) && best_value < bad_noisy_futility_margin) {
                     best_value = bad_noisy_futility_margin;
-                }
-                
+                }                
                 break;
             }
         }


### PR DESCRIPTION
```
Test  | bnfp
Elo   | 1.77 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 80274 W: 21450 L: 21041 D: 37783
Penta | [1025, 9624, 18546, 9801, 1141]
```
https://ob.cwchess.org/test/1592/

```
Test  | bnfp
Elo   | 4.07 +- 2.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19304 W: 4871 L: 4645 D: 9788
Penta | [93, 2231, 4791, 2431, 106]
```
https://ob.cwchess.org/test/1593/

bench: 12155224